### PR TITLE
Re-enable wake lock when navigating back to page

### DIFF
--- a/website/assets/reader.js
+++ b/website/assets/reader.js
@@ -513,6 +513,13 @@ async function releaseWakeLock() {
 // Request wake lock when the page loads
 window.addEventListener('load', requestWakeLock);
 
+// Request wake lock when the page is navigated back to
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'visible') {
+    requestWakeLock()
+  }
+});
+
 // Release wake lock when the page is unloaded (navigated away from or closed)
 window.addEventListener('beforeunload', releaseWakeLock);
 


### PR DESCRIPTION
Wake locks automatically releases when navigating to another tab, minimises it, or otherwise navigates away, apparently. By registering on `visibilitychange` we can request another wake lock when the user comes back.

[Source](https://javascript.plainenglish.io/thats-right-web-pages-can-also-keep-the-screen-from-turning-off-798acbf91a5e).

Fixes the second item of the Todo list in #920