### PR TITLE
553 to 623 fixes + modifier fixes

### DIFF
--- a/chapters/cont/556.txt
+++ b/chapters/cont/556.txt
@@ -132,7 +132,7 @@ A body whose average stats does not seem to exceed 1.
 This is why I wasn't sure I could win a fight against a bare-chested Kim Dokja.
 Kim Dokja.
 I have to meet him somehow.
-I don't know what caused me to be possess this man, but considering what's normal in web novels, I should be able to return to reality the moment I see the end of the scenarios.
+I don't know what caused me to possess this man, but considering what's normal in web novels, I should be able to return to reality the moment I see the end of the scenarios.
 So I needed to meet the main character of 'Omniscient Reader', who dies and comes back to life for the sake of his colleagues, and win his favor. It's the only way to increase your chances of survival in this cruel world.
 By the way, I'll have to survive here before you can meet Kim Dokja or anyone else.
 <&>「The first scenario requires you to kill 'one or more living things'.」

--- a/chapters/cont/557.txt
+++ b/chapters/cont/557.txt
@@ -12,7 +12,7 @@ I decided to check the gift from Kim Dokja.
 Let's see. Kim Dokja received a text file of 'Ways of Survival', so I assume I got something similar.
 But no matter how much I scrolled down, I couldn't see any attachments.
 —We're sending you a small gift in anticipation for your series.
-That was the end of the message. There was no attachments, and I didn't feel like I had a new exclusive skill.
+That was the end of the message. There were no attachments, and I didn't feel like I had a new exclusive skill.
 So what was it?
 I realized that the message was sent through a web novel platform.
 It happened to be the app I used to use.

--- a/chapters/cont/558.txt
+++ b/chapters/cont/558.txt
@@ -40,7 +40,7 @@ Normally, his gruff demeanor would have intimidated me.
 But today's Lee Hakhyun was different.
 "Anyway, if you want to listen to me, listen to me, and if you don't, go over there and keep pushing against the wall. Honestly, I don't care if only this ahjussi and I survive."
 This kind of brazenness would have impressed even Kim Dokja.
-Perhaps the persuasion worked, a few people looked at each other and shared their opiniones.
+Perhaps the persuasion worked, a few people looked at each other and shared their opinions.
 The most active was the deacon.
 "Brothers and sisters, let's hear what he has to say."
 "Let's do it. We're all going to live with it, aren't we?"
@@ -115,7 +115,7 @@ I felt a strange pang of guilt at the thought.
 How many people have died like this in my novel?
 <!>[The character 'Kim Cheolyang' begins to trust you.]
 It was then that I suddenly heard the character's inner thoughts.
-My heart started to best fast.
+My heart started to beat fast.
 I felt that something was finally coming.
 As expected, I had an exclusive skill.
 <!>[The exclusive skill 'Character List' has been activated.]

--- a/chapters/cont/559.txt
+++ b/chapters/cont/559.txt
@@ -169,7 +169,7 @@ After the Bureau intervened once to remove the 'bugs' from the scenario, the fir
 Therefore, the 'time penalty' will not be triggered this time.
 <!>[There are 20 minutes remaining.]
 With a beep, a timer appeared out of thin air, and Bihyung laughed.
-<@>[There are twenty minutes left now. If you don't want to die, keep your chin up. Especiially if you don't want to end up like your leaders.]
+<@>[There are twenty minutes left now. If you don't want to die, keep your chin up. Especially if you don't want to end up like your leaders.]
 With those words, the screen flashed with images of the National Assembly members' heads exploding.
 The frightened people stood back Inhorror.
 "What the hell is this―"

--- a/chapters/cont/560.txt
+++ b/chapters/cont/560.txt
@@ -143,7 +143,7 @@ I closed my eyes and imagined them safely completing the first scenario.
 I said, and they looked at each other. Eyes nervous, like worshippers waiting for a message from God.
 "Oh, there's something in front of me......."
 At that moment, God's message appeared in front of everyone.
-<!>[Due to excessive modifications to the current scenario, there is an error with system message display and payement compensation.]
+<!>[Due to excessive modifications to the current scenario, there is an error with system message display and payment compensation.]
 <!>[Scenario clear messages will be automatically delivered after the time limit has elapsed.]
 Someone muttered in surprise.
 "What the hell is this......."

--- a/chapters/cont/562.txt
+++ b/chapters/cont/562.txt
@@ -54,7 +54,7 @@ I looked at the big guy and activated [Character List.]
 <Character Summary>
 Name: Lee Cheoldoo
 Age: 39 years old
-Sponsor: None (one constellation is currently showing intereset in this person).
+Sponsor: None (one constellation is currently showing interest in this person).
 Exclusive Attributes: Gangster (general), Ex-convict (general)
 Exclusive Skills: [Dogfight Lv.3], [Bluff Lv.3], [Intimidation Lv.3], [Headbutting Lv.2]
 Overall Stats: [Physique Lv.7], [Strength Lv.7], [Agility Lv.6], [Magic Power Lv.1]

--- a/chapters/cont/566.txt
+++ b/chapters/cont/566.txt
@@ -2,7 +2,7 @@
 As I watched the men approaching with a fearsome momentum, I suddenly realized that I was in Omniscient Reader.
 This is 'Geumho Station', where a series of horrific murders have taken place.
 The men with the pipes were most likely members of the 'Cheoldoo Group', the mainstream group at Geumho Station.
-In a fortunate twist of fate, the original owner of Geumho Station was the character I possesed, Cheon Inho.
+In a fortunate twist of fate, the original owner of Geumho Station was the character I possessed, Cheon Inho.
 In other words, Cheon Inho became the owner of Geumho Station after he defeated all of those terrifying men from the Cheoldoo Group.
 How the hell did you do it, Cheon Inho?
 In the distance, I could see the men checking our area freeze in their tracks, because there was blood everywhere.

--- a/chapters/cont/567.txt
+++ b/chapters/cont/567.txt
@@ -197,7 +197,7 @@ Looking at Dansoo ahjussi nodding his head in understanding, I suddenly remember
 I looked at the back of Bang Cheolsoo's head, which looked a bit grim, and shook my head.
 Forget it. Now is not the time for such complicated thoughts.
 If Kim Dokja and the other main characters survived the first scenario, they will come to Geumho Station.
-If Kim Dokja was eaten by the ichtyosaur like in Omniscient Reader, it would be the group and Yoo Joonghyuk that would arrive here first.
+If Kim Dokja was eaten by the ichthyosaur like in Omniscient Reader, it would be the group and Yoo Joonghyuk that would arrive here first.
 If we wanted to give him a good impression, we'd need to turn this Cheoldoo Group bastards in the guards of Geumho Station.
 Bang Cheolsoo stopped walking.
 "We're here."

--- a/chapters/cont/569.txt
+++ b/chapters/cont/569.txt
@@ -120,7 +120,7 @@ Jung Heewon scratched her cheek at my strong denial and smiled.
 Suddenly, I understood why Jung Heewon was talking to me.
 <!>[The majority of your region now thinks of you as a leader.]
 <!>[You have conquered 'Geumho Station'.]
-<!>[You will recieve the sub scenario rewards.]
+<!>[You will receive the sub scenario rewards.]
 <!>[500 coins have been earned.]
 <!>[If you survive to the fourth main scenario, you will receive additional benefits from completing the sub scenario.]
 <!>[The constellation 'Sneaking Schemer' says your ploy is really pretty good.]
@@ -144,8 +144,8 @@ Kyung Sein nodded in understanding.
 "Sein-ssi should say it, not me. Do you think Kim Dokja or Yoo Joonghyuk would listen to me?"
 "Oh, yeah. Uh...... what should I say? I'm not good at talking. So where would they be by now?"
 "They're probably just finishing up the 'Even Bridge' scenario."
-In the main part of Omnscient Reader, Kim Dokja and the others are separated by the breaking of the Dongho Bridge.
-"Since Kim Dokja would have been eaten by the ichthyousaur straight away, we're likely to meet Yoo Joonghyuk, Lee Hyunsung, Yoo Sangah, Lee Gilyoung...... the other members first."
+In the main part of Omniscient Reader, Kim Dokja and the others are separated by the breaking of the Dongho Bridge.
+"Since Kim Dokja would have been eaten by the ichthyosaur straight away, we're likely to meet Yoo Joonghyuk, Lee Hyunsung, Yoo Sangah, Lee Gilyoung...... the other members first."
 That's what would be common sense.
 Of course, that's assuming the scenario plays out in the same way as in the original.
 "We'll probably meet Han Myungoh, too."

--- a/chapters/cont/573.txt
+++ b/chapters/cont/573.txt
@@ -8,7 +8,7 @@ Just before I collided with the surface, I felt like I was going to lose my mind
 <!>[Physique Lv.4 → Physique Lv.10]
 <!>[Your physique level has increased dramatically!]
 <!>[Your physical durability has increased dramatically!]
-<!>[Coin Possessed: 1,800 C]
+<!>[Coins Possessed: 1,800 C]
 My body was numb from head to toe from the impact, and my ears were deafening. I could feel my body temperature dropping rapidly.
 It was a message from the constellations that held my fading consciousness together.
 <!>[The constellation 'Sneaking Schemer' appreciates your survivability.]
@@ -54,7 +54,7 @@ The river raged in the darkness.
 Upon closer inspection, I realized we were sitting on the remains of a small plastic structure. I wondered if it was the remains of a sailboat used by the Han River rescue team.
 The air was strangely humid. I turned on my phone's flash and saw a wall of crimson above, below, and to the left.
 In the back of my mind, I remembered what happened before I lost consciousness.
-We had been eaten by an ichthyousaur.
+We had been eaten by an ichthyosaur.
 "You seem happy to have survived. We're about to die."
 I threw up water and smiled bitterly.
 The light from my cell phone cast the shadows of the two of us against the crimson stomach of the ichthyosaur.

--- a/chapters/cont/576.txt
+++ b/chapters/cont/576.txt
@@ -54,7 +54,7 @@ Her voice trembled slightly as she continued.
 After a moment of silence, Kyung Sein said as if determined.
 <&>「"I'm sure they're not dead. You know Inho-ssi isn't just a regular reader."」
 Kyung Sein glanced toward the tunnel leading to Geumho Station.
-<&>「In fact, she was already awake when Yoo Junghyuk passed by her. But she didn't move immediately. That's because her skill [Sixth Sense] warned her. 」
+<&>「In fact, she was already awake when Yoo Joonghyuk passed by her. But she didn't move immediately. That's because her skill [Sixth Sense] warned her. 」
 She had such a skill.
 <&>「[Sixth Sense] was telling her. If you wake up now, you will surely die. So Kyung Sein kept pretending to faint until Yoo Joonghyuk's presence completely disappeared.」
 If she had moved then, she might have really died.
@@ -68,7 +68,7 @@ Suddenly, I realized I could trust her in my absence.
 She knew exactly what resources we had. I also liked the fact that she didn't forget to check.
 The determined kkoma Kim Dokja was smiling subtly, as if he liked that fact.
 The girl knows what she's doing.
-<&>「There is one thing Kyung Sein must do first. Prevent Yoo Junghyuk from destroying the Cheoldoo Group.」
+<&>「There is one thing Kyung Sein must do first. Prevent Yoo Joonghyuk from destroying the Cheoldoo Group.」
 At best, I've incited Bang Cheolsoo to remove the danger from Geumho Station. We can't let that crazy Yoo Joonghyuk destroy our peaceful Geumho Station.
 Dansoo ahjussi finally agreed, and the two of them hurried to Geumho Station.
 Along the way, when they encountered a group of ground rats, they ran away from them, and when one appeared, they bravely fought it off.

--- a/chapters/cont/580.txt
+++ b/chapters/cont/580.txt
@@ -7,7 +7,7 @@ I should answer correctly.
 "Between friends!"
 Dansoo ahjussi suddenly exclaimed. He spoke with the speed of a scholarship quiz.
 He turned to me and muttered in a half-whisper.
-"My mate doesn't know, but that means 'between friends' this days. It sounds like he's happy to see you."
+"My mate doesn't know, but that means 'between friends' these days. It sounds like he's happy to see you."
 But no matter how I looked at it, those were not friendly eyes.
 The thorn in the man's hand slowly pointed at Dansoo ahjussi. The man's expression turned cold, and a breathless confrontation ensued.
 "9158!"
@@ -177,7 +177,7 @@ If it's a sleeping potion you can get early on, it's probably the stem of yanasp
 I don't know how they got it, but they were prepared.
 "Why did you do this?"
 "I have two reasons."
-Killeer King looked at the 'Dark Keeper' fallen on the distance.
+Killer King looked at the 'Dark Keeper' fallen on the distance.
 "One. You were going to attack us."
 "We weren't."
 "Two. I smell blood on you."

--- a/chapters/cont/583.txt
+++ b/chapters/cont/583.txt
@@ -153,7 +153,7 @@ Description: A shapeless weapon of the past. It could have been anything, but ul
 Come to think of it, I once designed an item like this. It was just a setting, and I didn't think it would be here.
 Once again, I feel certain.
 There are countless 'settings' in this world that didn't make it into the main story, but remained in my notes.
-<&>「So, did I make that settings, or did Han Sooyoung tell me about them?」
+<&>「So, did I make those settings, or did Han Sooyoung tell me about them?」
 It was then that Kyung Sein spoke up.
 "By the way, Inho-ssi."
 "Yes."

--- a/chapters/cont/585.txt
+++ b/chapters/cont/585.txt
@@ -57,19 +57,19 @@ If he makes good use of the notes I put in the box, he'll still get a decent inc
 Of course, whatever he gets will be less than the bracelet on my wrist.
 +
 [Item Information]
-Name: Idea of Almost Anything
+Name: Thoughts of Almost Everything
 Rating: Star Relic (遺物)
 Description: A mysterious slime that was once the product of a constellation's obsession of studying 'almost everything'.
 When worn, it increases Agility and Magic Power levels by 1 each.
 * 'Idea' can use 'mimicry'.
 +
 Formed Idea (意態).
-'Idea of Almost Anything' can mimic an item by touching it.
+'Thoughts of Almost Everything' can mimic an item by touching it.
 Since it's a top-rated item, it cannot mimic others simply by touching them, but only after certain conditions are met.
 Once successfully mimicked, the item can be used continuously until the mimicked form is destroyed.
-However, the 'Idea of Almost Anything' may, out of its own free will, refuse to obey its owner's 'mimicry command'.
+However, the 'Thoughts of Almost Everything' may, out of its own free will, refuse to obey its owner's 'mimicry command'.
 As you can probably tell from the description, this was a scam item. In theory, it could be almost anything.
-However, 'Idea of Almost Anything' had two fatal flaws.
+However, 'Thoughts of Almost Everything' had two fatal flaws.
 One was that you can't rely on it if you don't meet the 'mimicry' conditions.
 And the second was that the 'idea' itself could refuse the 'mimicry command'.
 So I guess it's not a scam item after all.

--- a/chapters/cont/587.txt
+++ b/chapters/cont/587.txt
@@ -113,7 +113,7 @@ I'm guessing it's the 'Plague-Carrying Rat' we fought a while back. Maybe there'
 "Do I still look like Sein?"
 The two were still talking about ghosts.
 By now, we were more than halfway through the tunnel. It was time to get ready.
-I unwrapped the 'Idea of Almost Everything' from my wrist.
+I unwrapped the 'Thoughts of Almost Everything' from my wrist.
 It was shaped like a bracelet now, but it could mimic any item it touched.
 I opened the list of items that could be mimicked.
 +
@@ -129,11 +129,11 @@ In preparation for this time, I put a few items on the mimicry list.
 <!>[The item can be mimicked for 1 hour.]
 One hour. That's more than enough.
 The problem is.
-<!>['Idea of Almost Anything' refuses to mimic.]
+<!>['Thoughts of Almost Everything' refuses to mimic.]
 This guy could refuse the mimicry.
 Two long narrow eyes and a mouth appeared on the ring of the bracelet, and a small babbling sound came out.
 "Si-jyo."
-That was the only downside to the item ego 'Idea of Almost Anything'.
+That was the only downside to the item ego 'Thoughts of Almost Everything'.
 I couldn't transform it into the shape I needed when I needed it.
 Of course, I had a solution.
 <!>[The exclusive skill 'Incite Lv.4' is activated!]
@@ -141,7 +141,7 @@ Of course, I had a solution.
 <!>[Incite is effective!]
 "Jyo—jyo!"
 With a mystic light, the bracelet's form began to change.
-<!>['Idea of Almost Anything' has become 'Damaged Samyeongdang's Bamboo Stick'.]
+<!>['Thoughts of Almost Everything' has become 'Damaged Samyeongdang's Bamboo Stick'.]
 <!>[The duration of the mimicry is 1 hour.]
 Sure enough, it looked exactly like 'Damaged Samyeongdang's Bamboo Stick'. The performance was the same.
 <!>[The constellation 'Bald General of Justice' is shocked!]

--- a/chapters/cont/591.txt
+++ b/chapters/cont/591.txt
@@ -75,7 +75,7 @@ Then, this time,
 <!>[The exclusive skill 'Incite Lv.4' is activated!]
 It was my turn to take responsibility for my words.
 <&>「Turn into an 'Old Iron Shield'.」
-At the same time as I used Incite, 'Idea of Almost Anything' glowed.
+At the same time as I used Incite, 'Thoughts of Almost Everything' glowed.
 When Yoo Joonghyuk looked up, the shells were already in front of him.
 Kwaaaaang!
 I blocked Yoo Joonghyuk's way by a hair's breadth. The impact felt like it would shatter my shield.

--- a/chapters/cont/594.txt
+++ b/chapters/cont/594.txt
@@ -17,7 +17,7 @@ By the way, he didn't recognize me after all.
 I hesitated for a moment, then decided to implement the plan I'd been thinking about.
 'Idea.'
 As I said the name in my head, the bracelet on my wrist twitched.
-I don't know exactly why, but unlike my other items, the 'Idea of Almost Anything' had been summoned here with me.
+I don't know exactly why, but unlike my other items, the 'Thoughts of Almost Everything' had been summoned here with me.
 Either way, it was a good thing for me right now.
 "Wait, I don't like hanging like this."
 I grabbed RepresentativeKimDokja's wrist, who gripped the back of my head while thinking. I could feel the surface of the bracelet resonating against his hand.

--- a/chapters/cont/598.txt
+++ b/chapters/cont/598.txt
@@ -71,7 +71,7 @@ I don't know if this will work.
 "Idea."
 Still, I had to try.
 "Let's go."
-'Idea of Almost Anything' gurgled into the bracelet.
+'Thoughts of Almost Everything' gurgled into the bracelet.
 I commanded it.
 <!>[The exclusive skill 'Incite Lv.5' is activated.]
 "Turn into the Ever-changing Stealth Suit."
@@ -163,10 +163,10 @@ But now I had no other choice.
 Poison Bomb. It was an item they left behind when we fought the Misreading Association.
 A biochemical weapon made from the anal sac of a poisonous rhinoceros.
 I picked up one of the used bombs at the time and put it on the possible mimicry list.
-<!>[The consumed item is restored by the effect of 'Idea of Almost Anything'.]
+<!>[The consumed item is restored by the effect of 'Thoughts of Almost Everything'.]
 <!>[The rare occasion of shape evolution has occurred!]
 <!>[The form of the item has evolved to a higher level!]
-<!>['Idea of Almost Anything' has turned into 'High-Level Poison Bomb'.]
+<!>['Thoughts of Almost Everything' has turned into 'High-Level Poison Bomb'.]
 A moment later, a faintly glowing bomb appeared in front of me.
 <!>[This item is a consumable item.]
 <!>[When the item is used, you won't be able to use the form again.]

--- a/chapters/cont/600.txt
+++ b/chapters/cont/600.txt
@@ -63,8 +63,8 @@ Ye Hyunwoo's eyes were calm as he looked at me. I answered, pretending to be cal
 Ye Hyunwoo smirked.
 "It's not that I think Inho-ssi is from the Misreading Association, I just......."
 I was a little nervous.
-Did Ye Hyunwoo see me use the 'Idea of Almost Anything'?
-Even though the 'Idea of Almost Everything' wasn't an item that appeared in Omniscient Reader, Ye Hyunwoo's perceptive mind could have picked up on something in that moment.
+Did Ye Hyunwoo see me use the 'Thoughts of Almost Everything'?
+Even though the 'Thoughts of Almost Everything' wasn't an item that appeared in Omniscient Reader, Ye Hyunwoo's perceptive mind could have picked up on something in that moment.
 "Inho-ssi."
 "Yes."
 "If you don't mind, can you get me an item from the fifth floor of the Theater Dungeon? I'll buy it."
@@ -78,7 +78,7 @@ Amazing. I know what it is.
 The question is.
 "But I don't know if that item is there......."
 "I'm sure it does. It was in a movie too. It wasn't in Omniscient Reader, but there's no way it isn't there, it must be there."
-Speaking seriously, Ye Hyunwoo glanced at the 'Idea of Almost Anything' wrapped in my arm and added.
+Speaking seriously, Ye Hyunwoo glanced at the 'Thoughts of Almost Everything' wrapped in my arm and added.
 "Because that's what I need for the '5th stage of the Invincible Castellan techtree'."
 What a clever reader.
 

--- a/chapters/cont/601.txt
+++ b/chapters/cont/601.txt
@@ -187,7 +187,7 @@ But then I heard another [Full Voice].
 This time, it was the old man. I could tell just by looking at him. He was the only one mumbling as if he were ventriloquizing.
 Nickname barampoong.
 6 reads.
-—There are two of us. We're fewer in number, but as you can see, I have [Full Voice] and one Sgrade skill. I think you're five...... Why don't you join forces with us?
+—There are two of us. We're fewer in number, but as you can see, I have [Full Voice] and one S-grade skill. I think you're five...... Why don't you join forces with us?
 Again, not a bad offer.
 By the way, there was already a behind-the-scenes war of nerves, they were meticulous people.
 However, they weren't the only readers.

--- a/chapters/cont/604.txt
+++ b/chapters/cont/604.txt
@@ -256,7 +256,7 @@ I wrote many sentences with my own hands. In the sentences I wrote, there must b
 "It’s alright. I can fix this. Don’t worry."
 A person is dying right in front of my eyes.
 My hands trembled and my head wasn't working well.
-I squeezed out the “Elaine Forest Essence” I had and applied it to the wound along with a ointment cream.
+I squeezed out the “Elaine Forest Essence” I had and applied it to the wound along with an ointment cream.
 In order to avoid the spread of poison, I cut ground rat jerky into small pieces and fed it to him with horn powder from the poisonous rhinoceros.
 Jung Jaewoo's throat wriggled and he started coughing up blood.
 Jung Jaewoo muttered while crying.

--- a/chapters/cont/605.txt
+++ b/chapters/cont/605.txt
@@ -217,15 +217,15 @@ Although he lost two of his teammates and even dropped Yongjun on the way back, 
 Yeom Ilwoo found a woman who arrived on the 5th floor before him.
 "Hey, look. Are you alone?"
 A short woman in a white coat.
-As soon as he checked the woman's face, Yeom llwoo's face brightened.
+As soon as he checked the woman's face, Yeom Ilwoo's face brightened.
 <!>[The constellation, 'King of Gambling', says you can't go that way.]
 Yeom Ilwoo ignored him.
 No matter who it was, it was an 'incarnation' who was here anyway, and with a high probability of being a 'reader'. And he was confident in deceiving any reader with his words.
 There surely can't be two crazy people who've read ORV 100 times.
 Above all, the woman's face was beautiful.
 "Let's team up together. I am the author of this novel! You heard it earlier, right? 'Omniscient Reader's Viewpoint’—"
-As soon as Yeom llwoo reached for the woman with a faint smile, an eerie sound split the air.
-Yeom llwoo did not know what happened until the moment his neck rolled down.
+As soon as Yeom Ilwoo reached for the woman with a faint smile, an eerie sound split the air.
+Yeom Ilwoo did not know what happened until the moment his neck rolled down.
 <!>[The constellation, 'King of Gambling', checks his eyes in astonishment!]
 <!>[The constellation, 'Sneaky Schemer', glares at the 'King of Gambling'.]
 <!>[The constellation, 'King of Gambling', hastily leaves the channel.]

--- a/chapters/cont/606.txt
+++ b/chapters/cont/606.txt
@@ -6,7 +6,7 @@ Why did you call me here?
 What story are you reading right now?
 <!>[Current state of consciousness is unstable.]
 Unfortunately, when I opened my eyes, it was not a snowy field.
-I could see the dark scene of the theater around me. It was a theater where kkoma Kim Dokjas was gathered..
+I could see the dark scene of the theater around me. It was a theater where kkoma Kim Dokjas were gathered..
 As soon as I woke up, I thought of Jung Jaewoo. At the last moment, Jung Jaewoo disappeared as a “kkoma Kim Dokja.”
 Maybe he's here too.
 People huddled around the theater and sat down. Small backs of heads were visible.
@@ -82,7 +82,7 @@ If it's half a day outside, did it come around the time the 'Emergency Defense B
 I belatedly realized my mistake.
 Why did I think the Misreading Association would only be among the “latecomers”?
 They must have read the exhibition through the illegal text, so the quick-witted ones among them must have infiltrated the theater dungeon beforehand.
-"The number is five in total. As soon as I entered the stage, I met them. Two were rats, and three were snakes. I killed them all, but the problem was that the snakes bit me as they died."
+"The number were five in total. As soon as I entered the stage, I met them. Two were rats, and three were snakes. I killed them all, but the problem was that the snakes bit me as they died."
 Saying that, Killer King showed his arm.
 There were traces of a snake's teeth on his pale arms, and a purple mark was engraved around the teeth marks.
 "It's a curse."
@@ -128,7 +128,7 @@ Of course, I thought he would use [Lie Detection], but I didn't hear the message
 After thinking for a while, Killer King asked.
 "Why did you leave the note?"
 At the time, I jotted down some useful information in the box I gave them.
-If it's Killer King, you've probably got quite a few hidden pieces that are good for that width by now.
+If it's Killer King, you've probably got quite a few hidden pieces that are good from that note by now.
 "You really don't know?"
 Killer King glared at me for a moment, then turned his head away with a face that seemed to have hurt his pride.
 "No. I think I know."

--- a/chapters/cont/607.txt
+++ b/chapters/cont/607.txt
@@ -88,10 +88,10 @@ Anyway, “Tyranno” was a success.
 Then.
 "I am."
 <!>[Exclusive skill, 'Incite Lv.6', is activated!]
-"I am the Snake that Cuts off its Tail."
+"I am the Snake That Cut Off Its Tail."
 Tsutsutsutsutsutsutsu!
 As expected, there seems to be a penalty for [Inciting] as someone with a higher rank than me. Pain surged through the blood vessels throughout my body, as if electricity were flowing instead of blood, and my consciousness flickered for a moment.
-<!>[The constellation, 'Tail-Cutting Snake', looks at you with astonished eyes.]
+<!>[The constellation, 'Snake That Cut Off Its Tail', looks at you with astonished eyes.]
 Still, it was probably because his level was low, and I was able to withstand this level of aftermath.
 I swallowed the rising blood. I thought I could say at least one word.
 "Go away!"
@@ -196,7 +196,7 @@ I shook my head and stood next to him.
 "I'll stay. You ride there."
 The master of the Cretaceous Period's lungs swelled greatly. Its breath will pour out soon.
 I'm ready to use [Incite].
-Even if I overdo it, let's become the Snake that cuts its tail one more time. Then I might be able to pick up the direction of its breath a little bit.
+Even if I overdo it, let's become the Snake That Cut Off Its Tail one more time. Then I might be able to pick up the direction of its breath a little bit.
 "It's a 6th-level earth dragon. It's not an opponent you can do anything about with [incite].
 "You have to do that to know."
 "I know even if I don't try. I've read the Revelation 100 times."

--- a/chapters/cont/608.txt
+++ b/chapters/cont/608.txt
@@ -86,7 +86,7 @@ The mimicry skill of [Thoughts of Almost Everything] increases!
 <!>[It learnt a new mimicry form!]
 Perhaps it was because its proficiency had risen, but now the conditions for collecting the shape of A-class or lower items were not so difficult.
 About 5 minutes after that, I collected most of the weapon shapes in the [Room of Reward].
-<!>[‘Thoughts of Almost Everything’ are satisfied with form prey.]
+<!>[‘Thoughts of Almost Everything’ is satisfied with its prey of forms.]
 Although there were no imitations of S-class or higher, if I collected this much, there would not be a shortage of weapons for a while. I finally chose one protective gear.
 Weapons can be summoned at any time using 'thought', but since protective gear must be worn at the same time, it was impossible to rely on the [Mimicry] function alone.
 <!>[External Reinforced Suit - Replica: A-class armor.]
@@ -122,7 +122,7 @@ It was torn, but the poster was underfoot.
 <!>[Only part of the film is reproduced.]
 With the feeling of the floor sinking, we were sucked into pitch black darkness. And when we woke up, we were locked in a room with white walls on six sides.
 ***
-rlaehrwk99 : Isn't that movie cue?
+rlaehrwk99 : Isn't that movie cube?
 rlaehrwk124: How old is 99?
 ***
 <!>[The film is not in perfect condition.]

--- a/chapters/cont/609.txt
+++ b/chapters/cont/609.txt
@@ -109,10 +109,10 @@ The exit was covered with pure white crystals, but I quickly realized what it wa
 It was clearly a trace of [steelization].
 Lee Hyunsung himself, or someone who borrowed Lee Hyunsung's skill blocked the door.
 Judging by the degree of crystallization, [steelization] is in its very early stage. It was also thin.
-Literature Girl 64 activated [White and Blue River] and knocked on the door as a test.
+Literature Girl 64 activated [White and Blue Steel] and knocked on the door as a test.
 Kaga!
-Even so, it was [White and Blue River], but she could only get a tiny blush.
-Even in the early stages, the intensity of [White and Blue River] is extraordinary.
+Even so, it was [White and Blue Steel], but she could only get a tiny blush.
+Even in the early stages, the intensity of [White and Blue Steel] is extraordinary.
 "There is a way."
 Literature Girl 64 said in a calm voice.
 "But I can't do it alone."
@@ -164,7 +164,7 @@ As if peeping into the future, all the variables around me came into view at a g
 Of course, it's not as good as real pro gamer Yoo Joonghyuk, but am I still good enough to imitate him?
 The flow that dwells in her fist, and the place where her fist is headed. And from the point of impact to the release of exploding magical power.
 I was able to get a zoom, and I was able to get a flower.
-Literature Girl 64's fist moved. Swirling white-blue magic power. Her regime, penetrating space like a flash war, exploded at the center of the door.
+Literature Girl 64's fist moved. Swirling white-blue magic power. Her fist, penetrating space like a flash war, exploded at the center of the door.
 I didn't ask for the name of the skill, but I thought I knew what the King might have called it.
 <&>「White Blue Fist.」
 Obviously, that would be the name.

--- a/chapters/cont/612.txt
+++ b/chapters/cont/612.txt
@@ -7,7 +7,7 @@ The sentences written by Han Sooyoung and rewritten by me.
 The moment I stretched out my hand into the air, I felt the story wrap around my fingertips.
 <&>「Sea Admiral Lee Jihye, smiling widely, was aiming her twin dragon sword at me.」
 The moment I held the sentence in my hand, a sword appeared in my hand along with a bright light.
-It is the holy relic of the maritime admiral.
+It is the holy relic of the Maritime War God.
 Lee Jihye's exclusive weapon, twin dragon swords.
 <&>「"Exterminate, twin dragon swords."」
 Lee Jihye of the 1,863rd turn finally reached the edge of the scenarios after going through a hellish scenario and going through training in Murim.
@@ -131,12 +131,12 @@ The bullet shot by Gong Pildu pierced my shoulder with a sound of fissit.
 <&>「Shooting arrows like rain and shooting various gun barrels, the chaos was like a thunderstorm.」
 <&>「"This is why I curse this land, but I can’t leave."」
 <&>「Therefore, Taejo is a dot, so the smallest is the greatest.」
-Maritime Admiral.
+Maritime War God.
 The first sword of Korea.
 Kyrgios.
-Maritime Admiral and Lee Jihye's Ghost Fleet exchanged artillery fire at the same time. A hazy sea fog obstructed the view from the continuous shelling.
-I approached Han Sooyoung in an instant with Kyrios's [All-In-One].
-The moment Han Sooyoung's shadow swayed through the fog, Cheok Joon-kyung's [Three Sword Clashes] was activated from her right hand.
+Maritime War God and Lee Jihye's Ghost Fleet exchanged artillery fire at the same time. A hazy sea fog obstructed the view from the continuous shelling.
+I approached Han Sooyoung in an instant with Kyrgios's [All-In-One].
+The moment Han Sooyoung's shadow swayed through the fog, Cheok Jungyeong's [Three Sword Clashes] was activated from her right hand.
 <&>「This is a sword made to deal with the sea.」
 However, before it could be activated, something grabbed my ankle. It was Yoo Sangah's [Arachne's Web].
 Subsequently, Lee Hyunsung’s [Mountain Breaker] slapped my shoulder, and Shin Yoosung's 'Chimera Dragon' breathed at me.

--- a/chapters/cont/614.txt
+++ b/chapters/cont/614.txt
@@ -4,7 +4,7 @@ Han Sooyoung asked.
 It was a chance to finally make up for their long years.
 Nevertheless, Yoo Jonghyuk abandoned the opportunity and came here with Biyoo.
 "If he’s here."
-Yoo Jung-hyeok looked at the door of the hospital room and continued.
+Yoo Jonghyuk looked at the door of the hospital room and continued.
 "And I had a hunch that he was going to do something strange."
 "You know you can’t return, right?"
 A regressor who has lived for a long time.
@@ -12,7 +12,7 @@ Yoo Jonghyuk, who has now stopped even returning, made the same choice as her at
 Han Sooyoung couldn't help but open her mouth.
 "Well, even if you go through the first door, you'll end up unemployed again. You say you don't even play games anymore?"
 "I will open it this time."
-Yoo Jung-hyeok's rough palm touched the doorknob of the hospital room.
+Yoo Jonghyuk's rough palm touched the doorknob of the hospital room.
 The moment the door moved slowly, Han Sooyoung grabbed Yoo Jonghyuk.
 "Wait for a sec."
 Yoo Jonghyuk looked at Han Sooyoung and said.
@@ -157,7 +157,7 @@ I continued to wield my sword while reciting an incantation.
 The moment the trail of the sword finally reached the neck of the Theater Owner, someone pulled my back strongly.
 When were they summoned?
 Two of Han Sooyoung's [avatars] were holding onto my shoulders. What followed was a strong jolt in my side and shin. The blade flew through the air in an instant, and I knelt on the floor.
-When I sat down with dizziness, I saw Jung Heewon, who vomited blood from her mouth, also lose consciousness and pass out.
+When I sat down with dizziness, I saw Jung Heewon, who vomited blood from her mouth, also lost consciousness and passed out.
 <!>['Incite'’s effect ends.]
 An enormous recoil engulfed Jung Heewon's entire body.
 "It was a failure." She said.

--- a/chapters/cont/617.txt
+++ b/chapters/cont/617.txt
@@ -99,7 +99,7 @@ An electric sound was heard from the other side of the universe. The light of th
 The nameless ones howled in pain, and the enraged deities of the other world roared with hateful rage.
 The outer gods representing all the abandoned things in the world were talking.
 <#>【Kim Dokja Company.】
-The universe vibrated ominously. Foreigners' eyes turned to Earth. The far-off legend in his gaze engulfed the entire galaxy andlS wriggled.
+The universe vibrated ominously. Foreigners' eyes turned to Earth. The far-off legend in his gaze engulfed the entire galaxy and wriggled.
 <#>【Calm down. It is not yet time for you to move.】
 Someone interrupted them.
 A being wearing a white coat was handling the burden of outer gods on behalf of Earth.

--- a/chapters/cont/618.txt
+++ b/chapters/cont/618.txt
@@ -167,7 +167,7 @@ The sudden remark made the leader silent for an instant.
 "Do you know the future?"
 Ye Hyunwoo replied.
 "Those of you who have been with me since the beginning of the scenarios will know how I did it."
-Some incarnations shook their heads. All of them were members of the building owners association who had been through the Chungmuro Station scenario with Ye Hyunwoo.
+Some incarnations nodded. All of them were members of the building owners association who had been through the Chungmuro Station scenario with Ye Hyunwoo.
 "Certainly, Hyunwoo was special. As soon as the scenario started, he also caught bugs."
 "That's right. Even in the second scenario, if Hyunwoo wasn't there, everyone would have died. Isn't that right, elder?"
 Then Gong Pildu, who was petting Max at the center of the platform, spoke.

--- a/chapters/cont/619.txt
+++ b/chapters/cont/619.txt
@@ -91,7 +91,7 @@ The boy will keep his promises, and he will keep people safe.
 The problem was then.
 All enemies coming forward will aim for Ye Hyeonwoo's life. Just as Kim Dokja in the main story made so many sacrifices.
 <!>[The constellation 'Red Mountain Army' is glaring at the incarnation 'Ye Hyeonwoo'.]
-<!>[The constellation 'Snake that cuts off its tail' snorts at 'Ye Heonwoo's remarks.]
+<!>[The constellation 'Snake That Cut Off Its Tail' snorts at 'Ye Heonwoo's remarks.]
 <!>[Very few constellations think that the incarnation 'Ye Hyunwoo' is arrogant.]
 Maybe it had already started.
 A group of people who are hostile to Ye Hyunwoo.

--- a/chapters/cont/620.txt
+++ b/chapters/cont/620.txt
@@ -178,7 +178,7 @@ With each hit, the translucent barrier began to crack.
 Kyung Sein became contemplative and shouted.
 "Inho-ssi! It's breaking!"
 I could have died here if I hadn’t scanned the shield beforehand.
-I used [Incite] to transform the form of 'Idea of almost everything' into 'Hercules' Shield'.
+I used [Incite] to transform the form of 'Thoughts of Almost Everything' into 'Hercules' Shield'.
 <!>[The special skill 'wide area defense' is activated!]
 Despite activating two layers of wide-area defenses, the firepower of the [Mini Turret] was formidable.
 As soon as the first barrier collapsed, Kyung Sein looked back at me.
@@ -211,7 +211,7 @@ Kyung Sein asked in a nervous voice.
 "No. If we take this, it will become a real war."
 Ye Hyunwoo was shooting cannonballs, and the apostles were also wielding weapons, but they weren't serious yet.
 Because we haven't gotten our hands on the 'white flag' yet.
-But if you hold the flag, the 5minutes timer runs from then on.
+But if you hold the flag, the 5 minutes timer runs from then on.
 Goo Seonah and Kim Kyungsik, who have been watching all the time, will also attack with all their might.
 Ye Hyunwoo and Gong Pildu will also pour more powerful shells.
 'No matter how strong we are, we can’t deal with the entire Chungmuro Station with just four people.'

--- a/chapters/cont/622.txt
+++ b/chapters/cont/622.txt
@@ -41,7 +41,7 @@ The person who came to us instead of the hesitantly babbling Kim Namwoon was the
 "No. We're following on our own."
 Lee Hyunsung, with his honest eyes, smiled, showing off his strong chest muscles.
 Looking at his naive expression, I realized once again that I had really entered Omniscient Reader.
-The real 'steel sword master' Lee Hyunsung.
+The real 'Steel Sword Master' Lee Hyunsung.
 I didn't have time to appreciate it because I was in the middle of the battle earlier, but seeing it this way made me thrilled.
 Suddenly something came to my mind and I looked back at Jung Heewon.
 However, Jung Heewon, who met Lee Hyunsung, did not seem to be particularly impressed.
@@ -141,12 +141,12 @@ Thinking of future fights, the battle we went through at Chungmuro Station was n
 Our enemies will be more clever than Ye Hyunwoo, more inconsiderate than Han Sooyoung, and more brutal than Gong Pildu.
 Just looking at the Misreading Association, whom I met a while ago, that is the case.
 They were tenacious, immeasurable in number, and a group of criminals who did not abide by social common sense.
-<!>[The constellation 'Tail-cutting Snake' is smirking at you.]
+<!>[The constellation 'Snake That Cut Off Its Tail' is smirking at you.]
 An indirect message that sounds scary to think about.
 They were the Constellations of the Misreading Association.
 <!>[The constellation 'Rat that Calls Plague' tells you to try your best.]
 I remember that little mouse that Asmodeus flowered last time, but it seems that the bird has crawled in again.
-<!>[The constellation 'Tail-cutting Snake' warns you that even if you die, you will not be able to step on the blunderer of the stars.]
+<!>[The constellation 'Snake That Cut Off Its Tail' warns you that even if you die, you will not be able to step on the blunderer of the stars.]
 It was a fight that was not fair.
 The members of the Misreading Association could spy on us anytime during the channel relay, and leak information to their incarnations.
 After thinking for a while, I called Bihyung through 'Dokkaebi Communication'.

--- a/chapters/cont/623.txt
+++ b/chapters/cont/623.txt
@@ -1,48 +1,47 @@
 <title>623 Episode 14 Hunting (2)
-<?>Please refrain from changing chapters’ format i.e. font, letter size, color, background, etc… If you really need to, please open a separate copy.Oddly enough, I felt that way.
+Oddly enough, I felt that way.
 I was sure that the guys who committed illegal acts in real life would do something similar here.
 —That can't be the case. How tight is the security of our management office...
 Even as Bihyung said that, he noticed that there was an uncomfortable corner somewhere.
 —Stay still. I'll find out soon and come back.
 Even after Bihyung disappeared, the provocations of the constellations of the Misreading Association continued.
 <!>[The constellation 'Rat that Calls Plague' says that it will be useless even if the bug-like people struggle.]
-<!>[The constellation 'Snake that cuts off its tail' says it's a lot of fun.]
+<!>[The constellation 'Snake That Cut Off Its Tail' says it's a lot of fun.]
 <!>[The constellation 'Rat Calling Plague' also says that the free world is the best.]
 Seeing the message resounding loudly, Kyung Sein frowned.
 "Those children."
 "Never mind them."
 Seeing them suddenly noisy, I thought it would be safe for the time being.
-In retrospect 'The rat that causes plague' was severely damaged by Asmodeus, and the 'snake that cuts off its tail' must have used too much probability to bestow protection on the '6th-grade lizardmen' in the theater dungeon.
+In retrospect 'The rat that causes plague' was severely damaged by Asmodeus, and the 'Snake That Cut Off Its Tail' must have used too much probability to bestow protection on the '6th-grade lizardmen' in the theater dungeon.
 In other words, there wasn't much room left for them anymore.
-"The Snake that cuts off its tail."
-<!>[The constellation 'Snake ]
- cuts off its tail' is glaring at you.]
+"The Snake That Cut Off Its Tail."
+<!>[The constellation 'Snake That Cut Off Its Tail' is glaring at you.]
 "I heard that Killer King sent his regards, did you receive it well?"
-<!>[The constellation 'Snake cutting Tail' is showing its dignity towards you!]
+<!>[The constellation 'Snake That Cut Off Its Tail' is showing its dignity towards you!]
 Sparks faintly wrapped around my body.
 Still, just hearing the threat of a constellation and an indirect message sent chills down my spine.
-I would never have thought that this degree of probability would still remain in the 'tail-cutting snake'.
+I would never have thought that this degree of probability would still remain in the 'Snake That Cut Off Its Tail'.
 The moment when I was suffocating little by little due to the pressure that was slowly rising.
-<!>[The constellation 'The First Sword of Goryeo' says that if you don't keep quiet, your mouth will be torn.]
+<!>[The constellation 'Goryeo's First Sword' says that if you don't keep quiet, your mouth will be torn.]
 The message that flew through the air blew away the pressure as if it had been washed away.
 It is also CheokJungyeong.
-<!>[The constellation 'Tail-Cutting Snake' is embarrassed.]
-<!>[The constellation 'snake that cuts off its tail' warns you not to meddle in other people's affairs.]
+<!>[The constellation 'Snake That Cut Off Its Tail' is embarrassed.]
+<!>[The constellation 'Snake That Cut Off Its Tail' warns you not to meddle in other people's affairs.]
 Wait for a sec. Are you going against Cheok Jungyeong?
 Are you crazy?
 <!>[The constellation 'Snake Cutting its Tail' warns you not to mess around with great people.]
-<!>[Constellation, 'The First Sword of Goryeo' tells you to keep talking if you want to die.]
+<!>[Constellation, 'Goryeo's First Sword' tells you to keep talking if you want to die.]
 Or is it the eyes that haven't finished reading the novel right away?
-<!>[Constellation, 'The plague-causing rat' laughs at the threat of the First Sword of Goryeo.]
-<!>[Constellation 'tail-cutting snake' is old and can't make sense of things, and is quiet.]
-<!>[The constellation, 'First sword of Goryeo' warns them that if they say one more word, he will throw away his sword.]
-<!>[The constellation 'Snake that cuts off its tail' says to cut it if it can be cut.]
+<!>[Constellation, 'Plague-Carrying Rat' laughs at the threat of Goryeo's First Sword.]
+<!>[Constellation 'Snake That Cut Off Its Tail' is old and can't make sense of things, and is quiet.]
+<!>[The constellation, 'Goryeo's First Sword' warns them that if they say one more word, he will throw away his sword.]
+<!>[The constellation 'Snake That Cut Off Its Tail' says to cut it if it can be cut.]
 <!>[The constellation 'Rat that Brings Plague' is sarcastically saying that he doesn't know where they live.]
 Indeed. Maybe it was because they used to only write bad comments in real life, but their aggro skills were excellent.
-<!>[The constellation 'Prisoner of The Golden Headband' says it’s noisy and scratcheshis ears.]
+<!>[The constellation 'Prisoner of The Golden Headband' says it’s noisy and scratches his ears.]
 <!>[The constellation 'Abyssal Black Flame Dragon' warns you to fight like a man with your fists instead of talking loudly.]
 That's how the constellations in the channel frowned one by one, and the moment Cheok Joongyeong finally made a decision.
-<!>[Constellation 'the first sword of Goryeo' pulls out his sword.]
+<!>[Constellation 'Goryeo's First Sword' pulls out his sword.]
 A faint sound of electric lights resounded in the sky, and the disappeared Bihyung returned.
 <!>[Come on, Constellations. calm down. I will adjust the channel for a while.]
 The guy who was gasping for breath seemed to be exhausted somewhere.
@@ -55,15 +54,15 @@ These guys were committing illegal things here too.
 —A notice will come out from the administration soon. These bastards have been watching channels without paying a single fee until now.
 After a while, a system message was heard in the air.
 <!>[The Bureau of Sanctions has been updated.]
-<!>[The constellation 'Tail-cutting Snake'’s channel access has been temporarily restricted.]
-<!>[The constellation 'Plague Rat'’s channel has been temporarily restricted.]
+<!>[The constellation 'Snake That Cut Off Its Tail's channel access has been temporarily restricted.]
+<!>[The constellation 'Plague-Carrying Rat's channel has been temporarily restricted.]
 Apparently, there were other guys besides them who were subscribing to the channel illegally.
 I admired the excellent and prompt action of the Bureau. It would have been nice if the sanctions were done right away in real life.
 —This time, the matter was serious, so the management bureau decided to add a tracking request. I'm going to hire a fixer to collect the fine.
 'Who are you going to send?'
 I didn't even have to ask.
 It was because a message from the Management Bureau came straight away.
-<!>[The constellation 'The First Sword of Goryeo' accepts the Administrative Bureau's request for a solver.]
+<!>[The constellation 'Goryeo's First Sword' accepts the Administrative Bureau's request for a solver.]
 Misreading Association guys, you’re going to have a hard time for a while.
 It was then that Yoo Jonghyuk, who had been looking up into the sky, opened his mouth.
 "Lee Jihye. Kim Namwoon."
@@ -82,7 +81,7 @@ Yoo Jonghyuk continued to speak.
 Meteorite that fell on Seoul Tower.
 <!>[Gwicheol, Ingredients for Amcheonwolguk. Often found in the rainbow meteorite.]
 As expected, the sentence came naturally this time too. I was nervous, but there was no time to think about the sentence.
-It was because Yoo Jonghyuk immediately saw our width.
+It was because Yoo Jonghyuk immediately saw our group.
 "Dansu."
 He didn't expect him to remember his name, so he was a little surprised.
 "You follow Lee Jihye and Kim Namwoon."
@@ -146,7 +145,7 @@ Jung Heewon sighed lightly, and eventually shook her hand and stepped forward.
 "I don't die that easily."
 "Then why do you keep dying?"
 "Go ahead."
-With the sound of the cool wind, Jung Heewon's disappeared into the building. Even after her figure disappeared, Yoo Jonghyuk did not open his mouth for a while.
+With the sound of the cool wind, Jung Heewon disappeared into the building. Even after her figure disappeared, Yoo Jonghyuk did not open his mouth for a while.
 He was looking at the distant sky with solemn eyes. I could see the dark sunset dwelling in his pupils, burning red.
 "Cheon Inho."
 "Yes."

--- a/chapters/cont/629.txt
+++ b/chapters/cont/629.txt
@@ -130,7 +130,7 @@ rlaehrwk37: Oh shit.
 rlaehrwk99: Is it real?
 ***
 A miraculous reunion of two siblings who survived the hellish apocalypse.
-<!>[The constellation 'Maritime Admiral' nods at the tearful sibling reunion.]
+<!>[The constellation 'Maritime War God' nods at the tearful sibling reunion.]
 <!>[The constellation 'Demon-like Judge of Fire' observes the situation with a complicated expression.]
 <!>[The constellation 'Abyssal Black Flame Dragon' says that the spots should be matched.]
 If it was normal, it was the timing for the planned new wave to unfold. Tears and runny nose spilled out, the brother and sister hugged each other, brushed off old love and hatred, and realized true family love.

--- a/chapters/cont/633.txt
+++ b/chapters/cont/633.txt
@@ -166,8 +166,8 @@ The moment I thought that sentence, I felt like I had truly become a disciple of
 I was not afraid of anything.
 The smallest is the greatest.
 And I want to hit Yoo Jonghyuk in the back of the head. Perhaps they felt the atmosphere, and the complexion of the beggars lined up behind the Ark changed.
-The last point was [Blue and White River], which LiteratureGirl64 passed on to me.
-<!>[The exclusive skill 'White and Blue River Lv.1' is activated!]
+The last point was [White and Blue Steel], which LiteratureGirl64 passed on to me.
+<!>[The exclusive skill 'White and Blue Steel Lv.1' is activated!]
 Sensing bluish magic flowing from my body, Ark opened his eyes wide.
 He said, "You really were Kyrgios’s disciple."
 The beggars who were guarding him from behind were also greatly agitated.

--- a/chapters/cont/634.txt
+++ b/chapters/cont/634.txt
@@ -1,8 +1,8 @@
 <title>634 Episode 16 Mad Butcher (3)
 If you don't give me what I want right now, I'll call my master.
 At my simple declaration, the stars in the sky could be heard chattering.
-<!>[The constellation 'Bald General' smiles at your courageous spirit.]
-<!>[The Constellation 'First Sword of Goryeo' nods intriguedly.]
+<!>[The constellation 'Bald General of Justice' smiles at your courageous spirit.]
+<!>[The Constellation 'Goryeo's First Sword' nods intriguedly.]
 <!>[The constellation 'Abyssal Black Flame Dragon' asks who the teacher is.]
 <!>[A constellation that has not yet revealed their modifier makes an interested expression.]
 <!>[A constellation sensitive to the fashion of Murim is excited about the return of Kyrgios.]
@@ -56,9 +56,9 @@ Only then did I find the reason why he, who is a great person, can maintain his 
 I seemed to know.
 In order to come here, he sacrificed the stories he had accumulated over many years.
 Just as Yoo Jonghyuk chose to regress, the ark laid down all of his history to start the 'scenario' once again.
-<!>[The constellation 'The First Sword of Goryeo' grabs his tongue.]
+<!>[The constellation 'Goryeo's First Sword' grabs his tongue.]
 <!>[Constellation 'Bald General of Justice' goes to the place where the children play and asks what the senile Byul is doing.]
-<!>[The constellation 'Maritime Admiral' shakes his head.]
+<!>[The constellation 'Maritime War God' shakes his head.]
 I could see the fiercely twinkling stars through the open ceiling of Seoul Station.
 However, despite the scoldings from the constellations, the ark remained calm.
 "That's funny. Are those who are afraid to put down the story they have, and don't have the confidence to create the next story, so they just stay there, have the right to criticize me?

--- a/chapters/cont/635.txt
+++ b/chapters/cont/635.txt
@@ -22,7 +22,7 @@ The moment the Ark, who had bitten his lips, was about to open his mouth again.
 <!>[The constellation 'Prisoner of the Golden Headband' says it’s an interesting idea.]
 The stars of Seoul twinkled.
 <!>[The constellation 'Two-Legged Expert' sarcastically says that the Great Beggar Sect will reject the offer.]
-<!>[The constellation 'The First Sword of Goryeo' is interested.]
+<!>[The constellation 'Goryeo's First Sword' is interested.]
 <!>[The constellation 'Marine Admiral' feels nostalgic for old martial arts.]
 <!>[The constellation 'Bald General of Justice' likes to see the baton method after a long time.]
 <!>[The constellation 'Rice Cake-Eating Tiger' says that he also likes martial arts.]
@@ -186,7 +186,7 @@ However, the story is a little different if it is a confrontation that competes 
 As if he knew my intentions, the dragon head ark held a sneer.
 "Do you think you can beat me just because your overall stats went up a bit?"
 "Yes. This alone will be difficult."
-No matter how much I had the [White and Blue River], my skill level was only 1. However, if this wasn't a battle of inner strength through magical powers, I also had a good chance of winning.
+No matter how much I had the [White and Blue Steel], my skill level was only 1. However, if this wasn't a battle of inner strength through magical powers, I also had a good chance of winning.
 If there is no barrier of mana management, it is because I can mimic the 'depth' of the person I want with a high degree of plausibility.
 <!>[The exclusive skill 'Incite Lv.6' is activated to the limit!]
 I slowly closed my eyes and thought of the person I wanted in my head.

--- a/chapters/cont/636.txt
+++ b/chapters/cont/636.txt
@@ -89,8 +89,8 @@ Kyrgios’s defensive move to defend against flying arrows.
 Several fragments that could not be fully blocked quickly grazed my forearms and thighs.
 "That's funny. Kyrgios’s martial arts weren't like this at all."
 However, contrary to what he said, a small smile was forming from the corner of the Ark's mouth.
-<!>[The constellation 'The First Sword of Goryeo' makes an interested expression.]
-<!>[The constellation 'Maritime Admiral' feels an unknown charm in your battle.]
+<!>[The constellation 'Goryeo's First Sword' makes an interested expression.]
+<!>[The constellation 'Maritime War God' feels an unknown charm in your battle.]
 The constellations in the sky were watching our fight.
 <!>[The constellation 'Abyssal Black Flame Dragon' picks his nose, asking why they are so eager for such a trivial fight.]
 <!>[The constellation 'King of the Evil Stage' snorts.]
@@ -131,8 +131,8 @@ The expression on the ark's face was filled with joy.
 If someone had seen it, it would have been a terrible performance. There is no place to run away to, so there is no place to run, and there are times when I stumble and hit the floor with a weapon.
 However, the scene of rain unfolding in the head of the ark right now is a bit different from that.
 It would have been different.
-<!>[The constellation 'The First Sword of Goryeo' opens his mouth blankly.]
-<!>[Constellation 'Maritime Admiral' nods.]
+<!>[The constellation 'Goryeo's First Sword' opens his mouth blankly.]
+<!>[Constellation 'Maritime War God' nods.]
 <!>[The constellation 'Bald General of Justice' doubts his own eyes.]
 Some stories are only open to those who understand the context.
 For some, sentences that are useless at all, for others, draw a desperate landscape.
@@ -143,8 +143,8 @@ The utterly bewildered Ark murmured like a madman.
 The fight that ends is an illusion built up with lies.
 <&>「The batting stick of the ark against him hit the ground.」
 Even so, the moment the ark believed it. It became a reality.
-<!>[The constellation 'The First Sword of Goryeo' clenches his fist.]
-<!>[The constellation 'Maritime Admiral' exhales a sad breath.]
+<!>[The constellation 'Goryeo's First Sword' clenches his fist.]
+<!>[The constellation 'Maritime War God' exhales a sad breath.]
 <!>[The constellation 'Last Hero of the Yellow Mountain Bee' is immersed in the confrontation.]
 <!>[The constellation 'Bald General of Justice' is breathing heavily.]
 <!>[The constellation 'King Heungmu the Great' reluctantly licks his lips.]

--- a/chapters/cont/637.txt
+++ b/chapters/cont/637.txt
@@ -36,7 +36,7 @@ This naive star might have believed that he could become stronger if he really s
 So, it may be that he participated in this ordeal in order to develop his strength to once again challenge Kyrgios and the Slashing Swordsman in the sky.
 <&>「"The paradox of white-blue and the Pajeon Swordsman. I will meet them again someday, and I will surely be acknowledged."」
 But there was a contradiction in his story.
-<!>[The constellation 'Maritime Admiral' says it's okay to be honest.]
+<!>[The constellation 'Maritime War God' says it's okay to be honest.]
 <!>[The constellation 'Demon-like Judge of Fire' shakes her head slowly.]
 Why did he bother to start all over again?
 If the purpose was simply to meet Kyrgios or the celestial swordsman and seek revenge, it would have been possible while maintaining the status of a constellation.
@@ -92,7 +92,7 @@ The constellations were watching over me.
 Everyone is waiting for the point of this story.
 I opened my mouth.
 "A discussion."
-<!>[The constellation 'The First Sword of Goryeo' groans.]
+<!>[The constellation 'Goryeo's First Sword' groans.]
 Ark's eyes slowly widened.
 "I am a member of the political faction, and I want an agreement of the Beggar Sect, which was an old faction."
 Righteousness.
@@ -183,7 +183,7 @@ It seemed like a pitch black story was flowing from the whole body of the ark, b
 "That kind of story."
 The black-stained floor boiled over as if to swallow me.
 "We don't go along."
-<!>[The constellation 'Maritime Admiral' warns you of danger!]
+<!>[The constellation 'Maritime War God' warns you of danger!]
 <!>[The constellation 'Goryeo’s First Sword' is screaming!]
 <!>[The constellation 'Bald General of Justice'...]
 …

--- a/chapters/cont/638.txt
+++ b/chapters/cont/638.txt
@@ -24,7 +24,7 @@ I breathed in lightly and used 'punishment' once again.
 <!>[Increase the level of 'punishment'!]
 The purple flag sucked my mana, and an even more powerful electric shock burned the whole body of the ark.
 Eventually, the knees of the ark bent down.
-<!>[The constellation 'Maritime Admiral' admires your base!]
+<!>[The constellation 'Maritime War God' admires your base!]
 It was natural.
 Unfortunately, this world was not a favorable place for an Outer God.
 They were the beings who were abandoned in the 'scenario', and this was the world of the scenario.
@@ -178,9 +178,9 @@ Here is my 'inner world'.
 I turned my head to the place where I heard the strange laughter. I saw a guy who had infiltrated my world.
 The shape of a cephalopod about ten meters long. That seemed to be his body.
 It's smaller than the 'Dream Eater' that Kim Dokja dealt with, but at least he didn't seem to be an ordinary guy as he signed a contract with a constellation.
-<!>[The constellation 'Maritime Admiral' asks what happened.]
-<!>[The constellation 'The First Sword of Goryeo' says that it seems that a monster from the other world entered the body of that incarnation.]
-<!>[The constellation 'Bald General' sponsors you with 100 coins and asks if you're okay.]
+<!>[The constellation 'Maritime War God' asks what happened.]
+<!>[The constellation 'Goryeo's First Sword' says that it seems that a monster from the other world entered the body of that incarnation.]
+<!>[The constellation 'Bald General of Justice' sponsors you with 100 coins and asks if you're okay.]
 I heard a message from the stars who couldn't look inside me.
 <!>[The constellation 'Demon-like Judge of Fire' worries about your safety.]
 <!>[The constellation 'The Prisoner of the Golden Headband' asks the Administration Bureau to send out the screen.]
@@ -205,7 +205,7 @@ Just like when I fought with Han Sooyoung.
 <!>[The constellation 'Last Ark' sighs and breathes.]
 The magic of the [White and Blue Steel] that fills my whole body. As I slowly blinked, I could feel the energy of Kyrgios that brightly colored the surroundings.
 My magic-powered hair was dyed azure and swayed in the wind.
-<&>「Kyrios Rodgrim was there.」
+<&>「Kyrgios Rodgrim was there.」
 Perhaps realizing that something was wrong, the Outer God panicked and backed away from the floor, then started running away.
 <#>【Kak Kak Kak Kak Kak Kak Kak Kak】
 White-blue, the word that perfectly suited Kyrgios blossomed into a tale in my hands.

--- a/chapters/cont/640.txt
+++ b/chapters/cont/640.txt
@@ -59,7 +59,7 @@ Jung Heewon, who had stopped crying before I knew it, was collecting all the bel
 An infinitely calm, still, high-pitched voice. I also gathered my energy and answered her words.
 "Yes."
 As I looked up into the air, a message flew in as if it had been waiting for it.
-<!>[The constellation 'Maritime Admiral' sponsors you 100 coins.]
+<!>[The constellation 'Maritime War God' sponsors you 100 coins.]
 <!>[The constellation 'King Heungmu the Great' sponsors you 100 coins.]
 <!>[The constellation 'Bald General of Justice' sponsors you 100 coins.]
 <!>[The constellation 'Demon-like Judge of Fire' sponsors you 1,000 coins.]
@@ -100,7 +100,7 @@ If fewer constellations were watching me, I would have thought of that method.
 <!>[The constellation 'A Loan Shark Aiming For The Heart' says that you can exchange 100,000 coins for a summons' class elixir.]
 Damn kids.
 If I use the 'exchange' now, I will be able to buy elixirs at ridiculous prices.
-<!>[The constellation 'Maritime Admiral' argues that he is such a ridiculous profiteer.]
+<!>[The constellation 'Maritime War God' argues that he is such a ridiculous profiteer.]
 <!>[The constellation 'Merchant of the Daedong River' holds his tongue saying that there are people worse than him.]
 Fortunately, the worst was not assumed.
 I climbed onto the stage and looked at the dragon head ark and the meteorite guarded by the envoys.
@@ -159,9 +159,9 @@ If the basic story wasn't damaged, there was a possibility that he could fully r
 Did it last like 5 minutes?
 Jung Eunho's body suddenly began to convulse.
 I hurriedly checked Jung Eunho's veins.
-<!>[The constellation 'The First Sword of Goryeo' is silently gazing at the incarnation 'Jeong Eunho'.]
+<!>[The constellation 'Goryeo's First Sword' is silently gazing at the incarnation 'Jeong Eunho'.]
 Belatedly, I thought I wanted to go to sleep.
-<!>[The constellation 'Maritime Admiral' says that the boy is not yet ready to accept the elixir.]
+<!>[The constellation 'Maritime War God' says that the boy is not yet ready to accept the elixir.]
 It was a symptom commonly referred to as schizophrenia.
 <&>「In the case of the intoxication caused by the side effects of the elixir, there are two solutions. One is that, according to heavenly luck, the person involved in the orgasm will attain enlightenment. The second one is to deal with the runaway magic.」
 A phrase from the 'Ways of Survival' that came to mind naturally.

--- a/chapters/cont/641.txt
+++ b/chapters/cont/641.txt
@@ -52,7 +52,7 @@ Anyone would have been the same.
 No one can say to the boy who grew up through that misfortune, "You were the one who had to die."
 I thought about Han Sooyoung, who  wrote the 1,863 turns in 'Ways of Survival' and the dokkaebi king. She said the story will begin even if she doesn't write it, but the Dokkaebi King didn't tell her how the story would begin.
 And Han Sooyoung most certainly knew a story that could help 'Kim Dokja' survive.
-She wrote it, and Kim Dokja read it. Yoo Junghyuk lived the story and the three people met.
+She wrote it, and Kim Dokja read it. Yoo Joonghyuk lived the story and the three people met.
 A world where the beginning, the middle, and the end interlock. A circular universe where it is unknown who existed first.
 In front of a chain of causes and effects that seemed to bite their tails as if it were natural, I didn't know where to begin and how to cover the wrongs.
 When I raised my head, I saw Kim Dokja's face.
@@ -114,7 +114,7 @@ All stories have already been written, and are being written at the same time. I
 <&>「You asked me earlier if there is no meaning to a story in which the end is fixed.」
 Kim Dokja nodded his head. I looked down at my feet and said.
 <&>「I don't know the answer to your question yet. But I know at least one thing.」
-The tragedy of the 41st turn was written in 'Omniscient Reader'. This world ends in misfortune, and it is said to be one of the most terrible worlds among Yoo Junghyuk's numerous rounds.
+The tragedy of the 41st turn was written in 'Omniscient Reader'. This world ends in misfortune, and it is said to be one of the most terrible worlds among Yoo Joonghyuk's numerous rounds.
 <&>「I will stop the tragedy of this world.」
 I thought of the readers who entered this world. I thought of Dansu ahjussi, Kyung Sein, Killer King and Literature Girl 64, Ye Hyunwoo, Goo Seonah, and Kim Kyungsik.
 <&>「I will see the end of this world.」

--- a/chapters/cont/642.txt
+++ b/chapters/cont/642.txt
@@ -88,7 +88,7 @@ After thinking about it for a while, I decided to put all three roots of the 100
 The faces of the chattering people were much brighter than before.
 '100 Years Old Root' is the elixir that the ark left for the Beggar Sect. I also had two summoning pills left, so I wanted to use these elixirs to improve the survivability of the group members.
 <!>[The constellations from Murim admire your actions.]
-<!>[The constellation 'Maritime Admiral' nods at your thoughtfulness.]
+<!>[The constellation 'Maritime War God' nods at your thoughtfulness.]
 <!>[1,000 coins were sponsored.]
 The group members who ate a hearty breakfast after a long time looked more comfortable than before.
 When everyone had properly emptied their bowls, I opened my mouth again.

--- a/chapters/cont/643.txt
+++ b/chapters/cont/643.txt
@@ -19,7 +19,7 @@ Characteristic circulatory retardation.
 In the process of enduring Jung Eunho's coin incubation together, unexpected new things were obtained.
 It was a good income.
 Unfortunately, it was not a well-known martial arts characteristic like the Cheonmujiche or Thai Yin-Yangjiche, but it was a useful trait for me now in terms of increasing the efficiency of magic circulation.
-<!>[The constellation 'The First Sword of Goryeo' is interested in your growth rate.]
+<!>[The constellation 'Goryeo's First Sword' is interested in your growth rate.]
 Thanks to the efficiency of the circulatory delay, it is now possible to maximize 'Broken Faith' until it is broken.
 Even if I maintain the 'blade of faith' as an output, there was no lack of magic power.
 After sweeping through the crowd, I looked around and spoke in a loud voice.

--- a/chapters/cont/645.txt
+++ b/chapters/cont/645.txt
@@ -67,7 +67,7 @@ Occasionally I could see gear or clothing dropped by people, but I couldn't find
 It was definitely difficult for a single player dungeon.
 Defeating hundreds of Nagak and obtaining a notification of the award must be a formidable task for ordinary incarnations.
 <!>[The constellation 'Demon-like Judge of Fire' rejoices in your growth.]
-<!>[The constellation 'Maritime Admiral' says that he has caught on to his income.]
+<!>[The constellation 'Maritime War God' says that he has caught on to his income.]
 <!>[The constellation 'Bald General of Justice' says he heard that the horn meat is good for hair loss and strengthening stamina.]
 <!>[The constellation 'Prisoner of the Golden Headband asks if that's true.]
 The messages of the constellations came into my head.
@@ -102,7 +102,7 @@ There is no 'Unbreakable Faith', but there is 'Broken Faith' that can be infinit
 <!>[The constellation 'Bald General of Justice' says that the meat of the Ancient Nagak is in the limelight as a food to prevent hair loss.]
 <!>[The constellation 'Prisoner of the Golden Headband' asks if it's real.]
 <!>[The constellation 'Bald General of Justice' bets his hair and says it's real.]
-<!>[The constellation 'Maritime Admiral' says that this 'Bald General of Justice'has never eaten Nagaks’ meat.]
+<!>[The constellation 'Maritime War God' says that this 'Bald General of Justice'has never eaten Nagaks’ meat.]
 …
 <!>[A new bounty scenario has arrived!]
 +

--- a/chapters/cont/646.txt
+++ b/chapters/cont/646.txt
@@ -39,7 +39,7 @@ I sincerely bowed my head.
 "Thank you for saving me."
 "Ah, yes..... no!"
 In any case, if it weren't for this child, I would have fallen prey to the 'Ancient Nagak' without moving here.
-<!>[The constellation 'Maritime Admiral' admires the actions of this incarnation.]
+<!>[The constellation 'Maritime War God' admires the actions of this incarnation.]
 <!>[The constellation 'Demon-like Judge of Fire' is moved by the good deeds of incarnation 'Shin Yoosoung'.]
 A message from the constellations flying in the air.
 <!>[The constellation 'Demon-like Judge of Fire' sponsors 100 coins to incarnation 'Shin Yoosoung'.]

--- a/chapters/cont/648.txt
+++ b/chapters/cont/648.txt
@@ -35,7 +35,7 @@ But he was afraid of me. Not exactly me, but Shin Yoosoung.
 <!>[The constellation 'Prisoner of the Golden Headband' is curious about the taste of 'Raw Horn Meat'.]
 6th-grade monsters are scary to early incarnations. However, from the point of view of the constellations, incarnations and 6th-grade monsters were the same bugs.
 <!>[The constellation 'Bald General of Justice' says that when he was born, it was easy to have about 100 horns.]
-<!>[The constellation 'Maritime Admiral' says that there was no 'Field of Nagaks' at that time.]
+<!>[The constellation 'Maritime War God' says that there was no 'Field of Nagaks' at that time.]
 <!>[The constellation 'Abyssal Black Flame Dragon' makes fun of the conversation between the stars.]
 A constellation is, after all, a constellation.
 They are here to see the story. I and the Ancient Nagak had to spend our lives for them to survive.
@@ -164,7 +164,7 @@ Shin Yoosoung smiled.
 <!>[The constellation, 'Sneaky Schemer' says he can't go because he doesn't have someone to possess.]
 "It is very noisy. Don't these dokkaebis manage the channel?"
 When the child lightly looked up into the air, to her surprise, there was a faint spark.
-<!>[The constellation 'Maritime Admiral' is complaining that the screen transmission has been cut off from a while ago!]
+<!>[The constellation 'Maritime War God' is complaining that the screen transmission has been cut off from a while ago!]
 <!>[The constellation 'Bald General of Justice' says he thought only he was broken!]
 <!>[The constellation 'Abyssal Black Flame Dragon' threatens to request a refund from the administration if this continues.]
 <!>[The management bureau is checking the local channels.]

--- a/chapters/cont/654.txt
+++ b/chapters/cont/654.txt
@@ -74,7 +74,7 @@ By the way, are you insane for talking about things like that?
 It's a conversation that is filtered anyway, so they don't have any intention of hiding it.
 "What happened to the possessed constellation? Have you been contacted?"
 "No. Not yet. It looks like it's been a bit of time."
-"You damn bastards. Then why mess with the First Sword of Goryeo?"
+"You damn bastards. Then why mess with the Goryeo's First Sword?"
 "They don't even know the contents of their novels. We should have done the constellation possession."
 As the vibration that resonated with the labyrinth approached, the two men shut their mouths at the same time.
 "It’s coming."

--- a/chapters/cont/656.txt
+++ b/chapters/cont/656.txt
@@ -11,7 +11,7 @@ While the sound of something falling on the floor echoed one after another, no o
 I was alone.
 Probably like Yoo Jonghyuk always did.
 <!>[The constellation 'Maritime War God' is amazed at your martial arts.]
-<!>[The constellation 'First sword of Goryeo'...]
+<!>[The constellation 'Goryeo's First Sword'...]
 <!>[A handful of constellations sponsored 1,000 coins for your action.]
 A sense of limitless omnipotence and superiority dwelling in the body.
 This was Yoo Jonghyuk.

--- a/chapters/cont/658.txt
+++ b/chapters/cont/658.txt
@@ -157,7 +157,7 @@ All he could know was that there was a cause for all his unhappiness.
 "What, what. These bastards. Where did they come from?"
 “It’s an apostle! They are apostles!"
 "Ahhh!"
-"White and blue river! Ki, Kim Dokja?"
+"White and Blue Steel! Ki, Kim Dokja?"
 That someone made him suffer this way.
 —Ahjussi! Calm down!
 A distant voice as if coming from the other side of the universe.

--- a/chapters/cont/659.txt
+++ b/chapters/cont/659.txt
@@ -115,7 +115,7 @@ Light sparks flew from the body of Shin Yoosoung, who was manipulating the Nagak
 —You said he was close to you.
 Shin Yoosoung's golden eyes flickered. The eyes of a child who is looking at me but not looking at me at the same time.
 —You must never die.
-I ran while infusing [Broken Faith] with the [White and Blue River]. Cutting off the limbs of the incarnations with the new soldier's blade, I ran towards ahjussi.
+I ran while infusing [Broken Faith] with the [White and Blue Steel]. Cutting off the limbs of the incarnations with the new soldier's blade, I ran towards ahjussi.
 "Okay, throw it! Feed him another one!"
 But they were faster than me.
 The star jewel that flew through the air reached the dust man of Dansu ahjussi. With a whimpering sound, ahjussi’s whole body began to flatten once again.

--- a/chapters/cont/669.txt
+++ b/chapters/cont/669.txt
@@ -159,7 +159,7 @@ A person who can exist only in sentences.
 The stories that were clearly her memories now seemed like lies in a novel written by someone else.
 Han Sooyoung smiled as she looked at Yoo Jonghyuk's eyes that had turned white.
 "I’m about to die of happiness."
-Happiness. As she pronounced that word, Han Suyoung momentarily tilted her head.
+Happiness. As she pronounced that word, Han Sooyoung momentarily tilted her head.
 What was that?
 Is it because the avatar died and lost some of her memories? Han Sooyoung couldn't immediately remember the meaning of that word. Perhaps that wasn't all she had lost.
 However, she trusted Han Sooyoung.

--- a/chapters/cont/671.txt
+++ b/chapters/cont/671.txt
@@ -71,7 +71,7 @@ Asmodeus answered Han Sooyoung, who was swallowing her burning anger.
 "What nonsense-"
 Han Sooyoung looked at the kkoma Kim Dokja in the audience. A number so large that it cannot be contained at a glance. The number was greater than all the readers in this world combined.
 No way?
-The moment when Han Suyoung, who was in great shape, was about to open her mouth to Asmodeus.
+The moment when Han Sooyoung, who was in great shape, was about to open her mouth to Asmodeus.
 <&>「"What are you going to do if you go through the first portal and find Kim Dokja again, who is not good enough? Are you going to believe that the dog is Kim Dokja this time?"」
 A familiar story was heard from somewhere.
 <&>「"And the fragments of Kim Dokja who imagined that kind of ending, I will go to each and every one of them and torment them until they come up with a proper ending."」

--- a/chapters/cont/680.txt
+++ b/chapters/cont/680.txt
@@ -59,7 +59,7 @@ My mind was confused.
 What happened?
 What about Han Sooyoung?
 What about the Outer God?
-What about Yoo Junghyuk?
+What about Yoo Joonghyuk?
 Did we succeed?
 When I opened my eyes with difficulty and looked ahead, I saw the shape of a familiar person.
 Kind eyes shining beneath the devoted eyebrows.

--- a/chapters/cont/683.txt
+++ b/chapters/cont/683.txt
@@ -1,5 +1,5 @@
 <title>683 Episode 22 Name (5)
-<?>Please refrain from changing chapters’ format i.e. font, letter size, color, background, etc… If you really need to, please open a separate copy.At first, I wanted to argue.
+At first, I wanted to argue.
 After falling into this world out of nowhere, I lived quite diligently.
 In order to survive, I risked my life and nearly died.
 Even though I couldn't live like Kim Dokja, I thought I still had something to say.

--- a/chapters/cont/705.txt
+++ b/chapters/cont/705.txt
@@ -75,7 +75,7 @@ It feels like a layer of film is being placed on my soul, like wearing hard yet 
 As I slowly blinked, the scenery of the world changed. The high sky became even lower, and the gaze of the constellations felt more blatant.
 <!>[Some constellations are surprised by your status! ]
 <!>[The constellations of the National Tree pay homage to your status .]
-<!>[The constellation 'Bald General' is surprised as to whether you actually have hidden powers.]
+<!>[The constellation 'Bald General of Justice' is surprised as to whether you actually have hidden powers.]
 <!>[The constellation 'Maritime War God' is looking closely at your story.]
 <!>[The constellation 'Abyssal Black Flame Dragon' looks at you with his eyes wide open.]
 Christina, who was standing a few steps away, stumbled.

--- a/chapters/cont/706.txt
+++ b/chapters/cont/706.txt
@@ -116,7 +116,7 @@ The woman at the back of James came forward and said.
 "Anna Croft, like you."
 Anna, who looked dazzled, muttered as she shook her head.
 "No way ... what are you—"
-<!>[The constellation 'Bald General' is astonished at the choice of the incarnation!]
+<!>[The constellation 'Bald General of Justice' is astonished at the choice of the incarnation!]
 <!>[The constellation 'Maritime War God' is questioning  his eyes!]
 <!>[The constellation 'King Heungmu the Great' shouts that you are insane!]
 However, even the dissatisfied constellations could not dare to take a gesture beyond indirect message.

--- a/chapters/cont/712.txt
+++ b/chapters/cont/712.txt
@@ -15,7 +15,7 @@ According to Han Sooyoung’s memories, the purpose of <Kim Dokja Company> is to
 Maybe my presence was a distraction to them.
 —It would be nice if the Earth didn't explode like this.
 'No, but still...'
-I always think about it, but Kim Dokja's impression of Yoo Junghyuk was a bit crooked. How could Yoo Jonghyuk have even done something like that?
+I always think about it, but Kim Dokja's impression of Yoo Joonghyuk was a bit crooked. How could Yoo Jonghyuk have even done something like that?
 Still, it was true that I was worried at the same time.
 If, like Han Sooyoung, Yoo Jonghyuk also tries to get Kim Dokja back in the form of 'quickly destroying this world'...
 —But shouldn’t you run fast?

--- a/chapters/cont/720.txt
+++ b/chapters/cont/720.txt
@@ -1,5 +1,5 @@
 <title>720 Episode 27 Recycling Center (3)
-<?>Please refrain from changing chapters’ format i.e. font, letter size, color, background, etc… If you really need to, please open a separate copy."Now, choose this before you go in."
+"Now, choose this before you go in."
 The guide searched in her arms and immediately handed me a catalog.
 In the catalog, there was a drawing of an animal-shaped mask similar to the one worn by the guide.
 "What is this?"

--- a/chapters/cont/745.txt
+++ b/chapters/cont/745.txt
@@ -10,7 +10,7 @@ The story remains.
 <!>[The story 'The One Who Murdered a God of The Other World' begins its storytelling.]
 And that was the beginning of the 137th round in question.
 <!>[The constellation 'Nail-Eating Rat' is glaring at incarnation Yoo Jonghyuk.]
-<!>[The constellation tells you to attend the 'Zodiac Ball' if you want to clash with the 'Plague Rat'.]
+<!>[The constellation tells you to attend the 'Zodiac Ball' if you want to clash with the 'Plague-Carrying Rat'.]
 It was a provocation that he would not normally respond to. However, in the 137th round, Yoo Jonghyuk had defeated the 'Dream Eater', a deity from another world, and his liver had come out of his stomach (this is Han Sooyoung's expression), and although he usually did not avoid fights, he did not avoid it even more this time.
 As a result, Yoo Jonghyuk falls into a trap at the 'Zodiac Ball' and is lynched to death.
 The last thing the dying Yoo Jonghyuk saw was a rabbit stealing his liver and a rat eating his fingernails.

--- a/chapters/cont/762.txt
+++ b/chapters/cont/762.txt
@@ -110,7 +110,7 @@ I sat at the table and looked at the symbols of other constellations. There were
 The composition of the banquet hall itself was not much different from that of the 'Constellations Banquet'.
 What can be seen in the hall on the first floor are mainly great-grade constellations in the form of symbols. Most of them were not easy to recognize just by looking at their appearance.
 I started by looking at those who used relatively easy symbolism.
-Of course, the huge rice cake over there must be the tiger eating rice cake (the rice cake was torn off in several places, as if he had been seriously injured in the confrontation with me), and is the swollen liver the 'liverless rabbit'? A cut off rattlesnake's tail is the 'snake that cuts off its tail'.
+Of course, the huge rice cake over there must be the tiger eating rice cake (the rice cake was torn off in several places, as if he had been seriously injured in the confrontation with me), and is the swollen liver the 'liverless rabbit'? A cut off rattlesnake's tail is the 'Snake That Cut Off Its Tail'.
 Meanwhile, I also saw a familiar face.
 On the left table, the fingernails that had been scratching the table were creeping towards me.
 Rat eating fingernails.

--- a/chapters/cont/763.txt
+++ b/chapters/cont/763.txt
@@ -1,5 +1,5 @@
 <title>763 Episode 33 Ball (2)
-<?>Please refrain from changing chapters’ format i.e. font, letter size, color, background, etc… If you really need to, please open a separate copy.<!>[You all know who I’m talking about, right? 'Gourmet Association' people especially.]
+<!>[You all know who I’m talking about, right? 'Gourmet Association' people especially.]
 The concentration of attention was burdensome.
 Light laughter was heard from the second floor. It seemed like someone was muttering,”Is that Kim Dokja?"
 <!>[The constellations of the 'Gourmet Association' are looking at you.]

--- a/chapters/cont/766.txt
+++ b/chapters/cont/766.txt
@@ -74,7 +74,7 @@ Even though my face has clearly changed to that of Kim Dokja, my squinted eyes c
 "Didn’t you hear Teacher Yang tell you not to smoke?"
 "I would have said this wasn’t a cigarette."
 We stood side by side in front of the rooftop railing.
-When I think about it, I have never had an honest conversation with Yoo Jonghyuk from the 41st round. This is because conversations with Yoo Junghyuk were always filled with lies for survival.
+When I think about it, I have never had an honest conversation with Yoo Jonghyuk from the 41st round. This is because conversations with Yoo Joonghyuk were always filled with lies for survival.
 But what about now?
 Even now, does he still perceive me as a 'villain who must be killed if he fails'?
 "If you just throw it away, we’ll have to pick it up again—"
@@ -145,7 +145,7 @@ It seems that 41th round Yoo Jonghyuk also doesn't know where the real owner of 
 —There is no way he would have given up his body so obediently. There must have been a purpose.
 —Are you familiar with Cheon Inho?
 It was a question I had always wondered about.
-What on earth was the relationship between Yoo Junghyuk and Cheon Inho in 40th round?
+What on earth was the relationship between Yoo Joonghyuk and Cheon Inho in 40th round?
 In Anna Croft's memories, the two were enemies. They were also enemies of Bulbuldaecheon, who aimed their swords at each other and aimed at each other's necks.
 —I do not know.
 —For that matter, did you make any promises?

--- a/chapters/cont/770.txt
+++ b/chapters/cont/770.txt
@@ -134,7 +134,7 @@ On the surface, this scenario represents the 'graduation exam' of 『Infinite Pr
 The constellations of the Zodiac, readers from all over, and even the Recycling Center Director—know what the hidden purpose of this scenario is.
 <&>「The key to this scenario is the collection of 'Kim Dokja Fragments'.」
 How many more readers will die this time?
-<!>[The constellation 'Plague Rat' is looking for you.]
+<!>[The constellation 'Plague-Carrying Rat' is looking for you.]
 At the constellation's command, students began wandering around looking for me. In the past, I would have run away, but things are different now.
 I am the representative of the 'Demon King of Salvation'.
 Now it was enough to fight against the Constellations of the Misreading Association.

--- a/chapters/cont/773.txt
+++ b/chapters/cont/773.txt
@@ -5,7 +5,7 @@ The important thing here is that not all 'constellations within the same channel
 Unlike the 'Judge of Evil's' [Time of Judgment], which does not activate even if only one of the 'Absolute Good' constellations opposes it, the [Time of Judgment] of the 'Judge of Destruction' can be activated even if only one constellation agrees.
 <!>[The constellation 'Demon King of Salvation (Agent)' has agreed to the activation of the Time of Judgment.]
 In other words, [Time of Judgment] can be activated even if there is only one constellation that agrees within the channel.
-<!>[The constellation 'Plague Rat' opposes the activation of 'Time of Judgment'!]
+<!>[The constellation 'Plague-Carrying Rat' opposes the activation of 'Time of Judgment'!]
 <!>[The constellation 'Serpent Cutting Its Tail' opposes the activation of 'Time of Judgment'!]
 <!>[The constellation 'dog that threw itself into the flames' opposes the activation of 'Time of Judgment'!]
 As expected, there was opposition from the beggars. But there is no use in opposing it.

--- a/chapters/cont/779.txt
+++ b/chapters/cont/779.txt
@@ -51,19 +51,19 @@ As soon as Asmodeus's incarnation disappeared, the nearby grass began to rustle.
 <!>[Found it.]
 The incarnations that were smiling strangely at her were there.
 Students of Class B. The terminals of the incarnations of <Twelve Zodiac Signs>.
-A rat that brought plagues. And a snake that cut off its tail.
+A rat that brought plagues. And a Snake That Cut Off Its Tail.
 She also knew the owners of those incarnations. Once members of the Misreading Association, now they are the ones whose egos have been eaten by stories.
 There are people who have maintained a similar relationship with her since their personalities changed.
 But now.
 The moment she saw them, a cold sensation ran up her spine.
 Something is different.
 <!>[The constellation 'rat that brings plague' is looking at you.]
-<!>[The constellation 'snake that cuts off its tail' is looking at you.]
+<!>[The constellation 'Snake That Cut Off Its Tail' is looking at you.]
 The fist that flew in in an instant pierced her stomach. She couldn’t rest properly. Blood burst out with a sound, and a sharp pain surged from her entrails.
 <!>[It seems much weaker than I expected.]
 It felt like her neck would break at any moment in their grip.
 'This can't be happening.'
-The 'snake that cuts off its tail' and the 'rat that brings plague' that she knew were already as weak as they could be. After fighting against Cheon Inho repeatedly and getting hit by the aftermath of the probability explosions, she was now so damaged that she could not properly carry out the scenario.
+The 'Snake That Cut Off Its Tail' and the 'rat that brings plague' that she knew were already as weak as they could be. After fighting against Cheon Inho repeatedly and getting hit by the aftermath of the probability explosions, she was now so damaged that she could not properly carry out the scenario.
 But where on earth did they get this strength?
 <!>[After all, I bought an expensive ancestral tablet and a modifier.]
 Buying a modifier?
@@ -84,7 +84,7 @@ She wasn’t sure.
 Now, Goo Seonah didn’t have much magic left. The previous fight had squeezed the story to its limit.
 <!>[Then what about this guy?]
 <!>[Just kill her.]
-The 'Plague Rat' pulled out its long claw and swung its weapon at Goo Seonah.
+The 'Plague-Carrying Rat' pulled out its long claw and swung its weapon at Goo Seonah.
 A blow that could neither be avoided nor blocked.
 The moment she closed her eyes tightly, something heavy collided with her.
 <!>[School?]
@@ -223,7 +223,7 @@ My back which was carrying her slowly felt lighter. When I looked back, her body
 I got up from my seat with Ravelinger in my hand.
 I saw two constellations running after harming the water.
 <!>[I finally found them.]
-'Plague-bringing rat' and 'Tail-cutting snake'.
+'Plague-bringing rat' and 'Snake That Cut Off Its Tail'.
 To be exact, they were the ones wearing those masks.
 Judging from the stories I felt, they seemed to be from <Olympus> or <Asgard>. They had incarnations at their sides. Lee Hyunsung, Kim Namwoon, Lee Jihye, and even Shin Yoosoung.
 <!>[Today will be a big gain.]

--- a/chapters/cont/783.txt
+++ b/chapters/cont/783.txt
@@ -1,5 +1,5 @@
 <title>783 Episode 36 Real Kim Dokja (4)
-<?>Please refrain from changing chapters’ format i.e. font, letter size, color, background, etc… If you really need to, please open a separate copy.The air of the scenario he had been breathing for the first time in a while. Feeling the familiar yet unfamiliar density, Lee Gilyoung recalled the old advice of Kim Dokja.
+The air of the scenario he had been breathing for the first time in a while. Feeling the familiar yet unfamiliar density, Lee Gilyoung recalled the old advice of Kim Dokja.
 <&>「"That's right. Just breathe like that, exhale, and repeat slowly."」
 It was the breathing method that Kim Dokja had taught Lee Gilyoung, who had once wanted to learn martial arts.
 <&>「"What kind of method is this?"」

--- a/chapters/cont/792.txt
+++ b/chapters/cont/792.txt
@@ -108,7 +108,7 @@ He is Kim Dokja who understands the deepest sadness of anyone in this world.
 <&>「"If this continues, another sad story like you will be born."」
 And after a while, sentences began to appear on the newspaper again.
 ***
-Yoo Jonghyuk ran with me through the darkness. The universe was pitch black, and I couldn't see anything. We ran through that universe together. To be exact, Yoo Junghyuk ran alone, with me by his side.
+Yoo Jonghyuk ran with me through the darkness. The universe was pitch black, and I couldn't see anything. We ran through that universe together. To be exact, Yoo Joonghyuk ran alone, with me by his side.
 I squeezed out the voice that was barely coming out.
 "Yoo Jonghyuk."
 "Don't say anything. The stories are leaking."

--- a/chapters/cont/803.txt
+++ b/chapters/cont/803.txt
@@ -1,5 +1,5 @@
 <title>803 Episode 39 Rumor (2)
-<?>Please refrain from changing chapters’ format i.e. font, letter size, color, background, etc… If you really need to, please open a separate copy.During the Murim era when the system had not yet been introduced, the martial artists divided their martial arts proficiency into vague concepts such as '1-star' or '10-star'.
+During the Murim era when the system had not yet been introduced, the martial artists divided their martial arts proficiency into vague concepts such as '1-star' or '10-star'.
 However, the criteria for this 'star' were vague even among the martial artists.
 For example, some people said that the section where the sword handle glowed blue was '5-star of Changgung Muae Sword Technique', while others said that the section where the sword blade glowed blue was '5-star of Changgung Muae Sword Technique'.
 Because of that, if one of the family's masters started lying, saying, "I'm 10-star of Changgung Muae Sword Technique, but since then, the color of the sword has disappeared," it wasn't easy to even debunk that lie.

--- a/chapters/cont/815.txt
+++ b/chapters/cont/815.txt
@@ -217,7 +217,7 @@ What I wanted to ask was something else.
 The essence of the [Fourth Wall] is a 'library'.
 Inside it are the records and history of countless 'Ways of Survival' that Kim Dokja has read.
 —Well, that's right. If I knew, the [Fourth Wall] would be a bit different.
-But that's the main story, and the [Fourth Wall] that I restored for the kkoma Kim Dokjas was much more incomplete and smaller.
+But that's the main story, and the [Fourth Wall] that I restored for the kkoma Kim Dokjas were much more incomplete and smaller.
 —But as you know, there aren't that many records here. It's not a complete [Fourth Wall].
 "I know. But the information I'm looking for will be there."
 At least as long as the [Fourth Wall] contains the 'history of Kim Dokja', and as long as I'm a part of that 'Kim Dokja'— the 'record' I'm looking for is definitely there.

--- a/chapters/cont/851.txt
+++ b/chapters/cont/851.txt
@@ -111,7 +111,7 @@ A dwarf from a remote planet who goes around talking crazy about how the smalles
 Second Captain of the Transcendent Alliance, Kyrgios Rodgraim, the Paradoxical White-Blue.
 "Let's get started right away."
 As soon as he finished speaking, the two beings' bodies disappeared. For a moment, it seemed as if everything had been turned into a vacuum, and all sounds disappeared, before a terrifying thunderbolt exploded in the air. A storm of lightning that raged on without stopping.
-Every time Kyrios' [All-in-One] and Indra's [Thunderstorm] collided, the scenery of the night sky changed.
+Every time Kyrgios' [All-in-One] and Indra's [Thunderstorm] collided, the scenery of the night sky changed.
 <!>[The Constellation, 'God of Thunderbolt', activates the stigma 'Eye that Watches Over All'!]
 The Constellations let out a gasp of astonishment.
 The [Eye that Watches Over All]. It was the stigma that Indra used when he drew out his true power.
@@ -136,7 +136,7 @@ Indra's gigantic incarnation was revealed in the scattered raindrops. More than 
 A moment later, Indra, who had lost his balance, began to fall.
 <@>[Indra was defeated?]
 The Constellations were speechless at the shocking sight of the leader of <Lokapala> being defeated.
-Of course, Kyrios was not safe either. He had to give up one of his arms to defeat Indra, who was at full power, and he suffered major injuries to his back and chest. Even so, the fact that he was able to subdue Indra with only those wounds was an absurdity.
+Of course, Kyrgios was not safe either. He had to give up one of his arms to defeat Indra, who was at full power, and he suffered major injuries to his back and chest. Even so, the fact that he was able to subdue Indra with only those wounds was an absurdity.
 Even if the current leaders of the Transcendent Alliance were the strongest Transcendents, it would have been difficult for them to put up such a good fight against the leader of <Lokapala>.
 Nevertheless, there were two reasons why it was possible.
 One was that the incarnation they possessed was the 'best body' based on the difficulty level of the 'Final Scenario'.

--- a/chapters/cont/864.txt
+++ b/chapters/cont/864.txt
@@ -69,7 +69,7 @@ He knew it. Even so, it was not easy to accept that fact.
 Although it was not 'Ways of Survival', he felt that way even more after seeing the end of another novel. The boy trembled with fear as he imagined the characters in the novels he loved dying over time.
 <&>「What if 'Ways of Survival' ends like this?」
 The boy carefully imagined the ending of the story.
-Will the villain meet a villainous end? Will the supporting characters find their respective roles? Will Yoo Junghyuk finally figure out what his ■■ is?
+Will the villain meet a villainous end? Will the supporting characters find their respective roles? Will Yoo Joonghyuk finally figure out what his ■■ is?
 Will they eventually be happy?
 And will he, who watches them, be satisfied with that?
 Only after thinking that far did the boy realize.

--- a/chapters/orv/chap_00505.txt
+++ b/chapters/orv/chap_00505.txt
@@ -105,7 +105,7 @@ Along with those words, all traces of the Wenny King vanished. However, his mess
 "Ahjussi!!"
 Lee Jihye following us from behind suddenly cried out and disappeared through the floor. And then, hands-like things suddenly emerged from the floor and nearby walls to grab and yank at our arms and legs.
 "Jihye-yah!!"
-<!>[Character 'Lee Jihye', has become a part of the great story.]
+<!>[Character 'Lee Jihye' has become a part of the great story.]
 Jung Heewon reached out towards Lee Jihye being sucked into the floor. However, it was too late. Even Jung Heewon herself was being sucked in now.
 Walls transformed into bottomless quicksand and swallowed her up.
 <!>[Character 'Jung Heewon' has become a part of the great story.]

--- a/chapters/side/4.txt
+++ b/chapters/side/4.txt
@@ -281,7 +281,7 @@ Usually, people's reactions when they met Yoo Joonghyuk were fixed. Either open 
 However, the newcomer neither averted her eyes nor was shaken. Her presence was rather a calm face, as if it was only natural that she was here.
 "Oh right. Are you hungry?”
 
-The newcomer handed out a small paper bag to Yoo Jung-hyeok. Yoo Joonghyuk quietly lowered her eyes and looked down at the paper bag. Despite the cool expression, the newcomer continued.
+The newcomer handed out a small paper bag to Yoo Jonghyuk. Yoo Joonghyuk quietly lowered her eyes and looked down at the paper bag. Despite the cool expression, the newcomer continued.
 
 “It’s dumplings. Do you like it?”
 "Dumplings?"
@@ -381,7 +381,7 @@ Yoo Joonghyuk looked at the new recruit's notebook once and saw the face full of
 
 The rookie is worried about him.
 
-Yoo Jung-hyeok answered honestly.
+Yoo Jonghyuk answered honestly.
 "never mind."
 
 Yoo Joonghyuk felt a little regret after answering that. What he just said was clearly a favor. At least it wasn't a story to be answered in this way.
@@ -451,7 +451,7 @@ As the backbiting continued until the plate was empty, the newcomer shook her he
 Park Jinsang was looking at the back of the newcomer's head, who was blinded by cold eyes. Her voice was dull as if she had put on another mask in an instant.
 "I'd be horrified to find out what you two went through here."
 
-Looking at Park Jinsang’s shadowy eyes, Yoo Jung-hyeok realized that this was his main topic.
+Looking at Park Jinsang’s shadowy eyes, Yoo Jonghyuk realized that this was his main topic.
 
 “See you in the director’s office for a second.”
 <#>【… … Can you believe it?]】
@@ -488,7 +488,7 @@ Park Jinsang, who exhaled smoke with a hook, was a completely different person f
 
 “You know what’s going on these days, right? I… … how did we get here? Have you already forgotten everything?”
 
-He has the habit of squeezing someone else's shoulder on occasion. In fact, that appearance was the true face of Park Jinsang that Yoo Jung-hyeok remembered.
+He has the habit of squeezing someone else's shoulder on occasion. In fact, that appearance was the true face of Park Jinsang that Yoo Jonghyuk remembered.
 
 Coach Park Jin-sang.
 
@@ -617,7 +617,7 @@ Park Jinsang's face, laughing lightly, had changed to that of the coach before h
 
 Yoo Joonghyuk looked at Park Jinsang for a while, then turned around and left the room.
 
-Even after Yoo Junghyuk disappeared, Park Jinsang continued to smoke. Just as one of ashtrays turned into a hedgehog, it stood up with Park Jinsang letting out an eerie laugh.
+Even after Yoo Joonghyuk disappeared, Park Jinsang continued to smoke. Just as one of ashtrays turned into a hedgehog, it stood up with Park Jinsang letting out an eerie laugh.
 
 Park Jinsang immediately opened his cell phone and called somewhere.
 
@@ -1117,7 +1117,7 @@ Messages from the coach continued to fly on his cell phone.
 
 –Where are you?
 
-Yoo Jung-hyeok looked down at Yoo Mia, who was sleeping on his thigh, and calculated the remaining time and route until her arrival. Even if it was a bit late, he seemed to be able to arrive before his game time. The traffic congestion tended to ease as it approached the end of the boulevard. As expected, after that section—
+Yoo Jonghyuk looked down at Yoo Mia, who was sleeping on his thigh, and calculated the remaining time and route until her arrival. Even if it was a bit late, he seemed to be able to arrive before his game time. The traffic congestion tended to ease as it approached the end of the boulevard. As expected, after that section—
 
 With a squealing sound, a black sedan cut in on either side of the car.
 

--- a/scripts/side/side-555-602/chaps.txt
+++ b/scripts/side/side-555-602/chaps.txt
@@ -8986,7 +8986,7 @@ from the Misreading Association possessing constellations.
 "Do I still look like Sein?"
 The two were still talking about ghosts.
 By now, we were more than halfway through the tunnel. It was time to get ready.
-I unwrapped the 'Idea of Almost Everything' from my wrist.
+I unwrapped the 'Idea of Almost Anything' from my wrist.
 It was shaped like a bracelet now, but it could mimic any item it touched.
 I opened the list of items that could be mimicked.
 
@@ -12522,7 +12522,7 @@ Ye Hyunwoo smirked.
 "It's not that I think Inho-ssi is from the Misreading Association, I just......."
 I was a little nervous.
 Did Ye Hyunwoo see me use the 'Idea of Almost Anything'?
-Even though the 'Idea of Almost Everything' wasn't an item that appeared in Omniscient Reader,
+Even though the 'Idea of Almost Anything' wasn't an item that appeared in Omniscient Reader,
 Ye Hyunwoo's perceptive mind could have picked up on something in that moment.
 "Inho-ssi."
 "Yes."


### PR DESCRIPTION
fixed some grammatical mistakes / typos from chapters 553 to 623
fixed and renamed all instances of 'the first sword of Goryeo' to 'Goryeo's First Sword'
fixed the typos in 'Snake That Cut Off Its Tail's modifier
fixed the typos in 'Plague-Carrying Rat's modifier
fixed the typos in 'Bald General of Justice's modifier
fixed the typos in 'Maritime War God's modifier

I also renamed all instances of 'Idea of Almost Anything' / 'Idea of Almost Everything' into 'Thoughts of Almost Everything'
it just sounds better imo and is the same name used in the wiki

i will continue fixing typos as i continue reading the side stories im on chapter623 rn lol