### PR TITLE
Refactor chapter 297 text and image references

### DIFF
--- a/chapters/orv/chap_00297.txt
+++ b/chapters/orv/chap_00297.txt
@@ -83,8 +83,6 @@ Then the other Yoo Joonghyuk opened his mouth. "I…"
 The other Yoo Joonghyuk didn't talk but looked down at his ragged black coat. He threw his coat to the ground.
 "I want to live."
 The white coat worn by the collapsed Kim Namwoon had fallen to the ground. It was the Infinite Dimension Space Coat I lent him. Yoo Joonghyuk picked it up and wore it. The white coat fitted to his body like it was made for him from the beginning.
-<img>[297 - The white coat fitted to his body like it was made for him from the beginning.jpg][]
-<?>* Official novel illustration (canonical)
 The Yoo Joonghyuk in a white coat confronted the one in a black coat.
 "There is only one way."
 The two Yoo Joonghyuks pointed their Heaven Shaking Swords at each other.
@@ -124,5 +122,7 @@ Yoo Joonghyuk's figure started to scatter. I didn't hear any more of Yoo Joonghy
 Yoo Joonghyuk's appearance was fading into the light of this world. By the time I staggered towards him, Yoo Joonghyuk had already disappeared from the world. I looked back and saw Han Sooyoung sitting down with a despairing face.
 <!>[You have cleared the criteria of the Outer World Covenant.]
 The dazzling light filled the air like ashes, revealing a pale reality. In it, Yoo Joonghyuk was walking towards a world we didn't know.
+<img>[297 - The white coat fitted to his body like it was made for him from the beginning.jpg][]
+<?>* Official novel illustration (canonical)
 
 ***


### PR DESCRIPTION
The image wasn't from the scene where it previously was. It was described the scene at the end of the chapter. Therefore, i moved it to it's fitting place.