### PR TITLE
Fix character name from Jung Heewon to Lee Gilyoung in Chapter 32

### DIFF
--- a/chapters/orv/chap_00032.txt
+++ b/chapters/orv/chap_00032.txt
@@ -140,7 +140,7 @@ Lee Hyunsung caught me as I tried to get up.
 8:30… fortunately, not too much time passed. By the way, there was a face missing.
 "Where is Gilyoung?"
 "Ah, Gilyoung…"
-Before Jung Heewon spoke, I already discovered where Jung Heewon was. Lee Jihye and Yoo Joonghyuk were looking down at Lee Gilyoung a few steps away.
+Before Jung Heewon spoke, I already discovered where Lee Gilyoung was. Lee Jihye and Yoo Joonghyuk were looking down at Lee Gilyoung a few steps away.
 …No, what was that bastard Yoo Joonghyuk doing?
 At this moment, I remembered how Yoo Joonghyuk was surprised when he saw my party. Don't tell me, when Yoo Joonghyuk used Sage's Eye…?
 "When… you have chosen? Obvious never…before."


### PR DESCRIPTION
From the context it seems obvious that it should be Lee Gilyoung, as it is already known where Jung Heewon is, and Dokja is looking for Gilyoung. Furthermore, in the original Korean version this is the person he said he already knew were they were before Jung Heewon could speak: "이길영이." However, I relied on translator tools and OCR, so I might be mistaken.

This is an OCR excerpt from the original material, so its probably messed up a bit: 
"현성이 나를 붙잡았다.
"독자 씨! 안 됩니다. 한숨
도 못 주무셨지 않습니까?"
"지금이 몇 시죠?"
"오전 8시 30분입니다. 시
나리오가 끝나고 30분 정
도 지났습니다."
8시 30분이라...... 다행히
아직 시간이 많이 지나지
는 않았다. 그런데 보여야
할 얼굴이 하나 없다.
"길영이는 어디 있죠?"
"아, 길영이는......
정희원의 말을 잇기도 전
에, 나는 이길영이 어디에
있는 지 알 수 있었다."

<img width="1080" height="2340" alt="Screenshot_20260612_132118" src="https://github.com/user-attachments/assets/4fe3f972-45ca-4f8d-84bf-d970463da907" />