### PR TITLE
Fix typo in chapter 35

### DIFF
--- a/chapters/orv/chap_00035.txt
+++ b/chapters/orv/chap_00035.txt
@@ -208,7 +208,7 @@ The agitated Gong Pildu randomly fired. Lee Hyunsung spoke with admiration.
 "It is a really tremendous stigma. Is it okay when the magic power consumption is so big?"
 "It is a good stigma so it will be okay for a while."
 "Should we help…?"
-"Gong Pildu alone is sufficient. If we do down then he will be distracted and stop shooting."
+"Gong Pildu alone is sufficient. If we go down then he will be distracted and stop shooting."
 The Defense Master sponsor behind Gong Pildu was completely suited for this type of scenario. As long as he supported Gong Pildu, Gong Pildu wouldn't die here. As long as the sponsorship continued.
 I sat down and stretched out my legs.
 "We will be sucking honey for a while."


### PR DESCRIPTION
"Go" seems to make much more sense than "do" in this sentence and context. That is "(...) go down (...)" rather than "(...) do down (...)."