### PR TITLE
Fix wording for clarity in chapter 00424

### DIFF
--- a/chapters/orv/chap_00424.txt
+++ b/chapters/orv/chap_00424.txt
@@ -68,7 +68,7 @@ Yoo Joonghyuk dazedly looked back at his Master, and she addressed him again.
 
 ***
 
-The location of the new 'Giant Story' was four days away. It would've been so much quicker to get there by borrowing the powers of the Dokkaebis, but the current situation didn't permit that.
+The location of the new 'Giant Story' was four days away. It would've been much quicker to get there by borrowing the powers of the Dokkaebis, but the current situation didn't permit that.
 – You cannot borrow the powers of Dokkaebis you are friendly with.
 – You must never reveal the truth that you're 'Kim Dokja'.
 All thanks to the stinking agreement I had with the 'Wenny King'.
@@ -78,7 +78,7 @@ The kkoma Yoo Joonghyuk number [999] polishing his [Splitting the Sky Sword] ato
 "Then, why don't you drive? By the way, you're not planning to stick to that appearance now, are you?"
 Without a doubt, we'd run into Constellations that will recognise us once we entered the scenario location. The existence of the kkoma Yoo Joonghyuk was just too eye-catching.
 Well, Yoo Joonghyuk himself was just too famous by now, so…
-"Indeed, I am too inconspicuous like this."
+"Indeed, I am too conspicuous like this."
 [999] seemed to be pondering something. His body suddenly jolted a bit, before a 'Pow!' noise resounded out and he transformed into a Murim dumpling.]
 I was shocked silly by this event. But [999] sounded utterly disinterested as he addressed me.
 – This should be fine.


### PR DESCRIPTION
Corrected the wording from 'so much quicker' to 'much quicker' and 'inconspicuous' to 'conspicuous' for clarity. 
 'so much quicker' didn't fit with the writing style so far, and inconspicuous describes something common or easily missed, when in reality the kkomi YJH was the opposite.