### PR TITLE
Fix main story chapter edit links

### DIFF
--- a/scripts/main_epub_processor/htmlBuilder.py
+++ b/scripts/main_epub_processor/htmlBuilder.py
@@ -194,7 +194,7 @@ for file_index, file in enumerate(os.listdir("chapters/orv")):
         html.append("<hr>")
 
         template = template.replace(r"{{CONTENT}}",str("\n".join(html)))
-        template = template.replace(r"{{PATH}}",f"side/{file}")
+        template = template.replace(r"{{PATH}}",f"orv/{file}")
         template = template.replace(r"{{INDEX}}", str(file_index))
 
         discussion_id = discussion_map.get(file_index, "")


### PR DESCRIPTION
## Description

Fixes #1985

It was caused by a typo in `scripts/main_epub_processor/htmlBuilder.py`
The main-story builder used:

`template = template.replace(r"{{PATH}}",f"side/{file}")`

instead of:

`template = template.replace(r"{{PATH}}",f"orv/{file}")`

As a result, the generated Edit link for a main-story chapter points to `chapters/side/` instead of `chapters/orv/`

I changed `side/{file}` to `orv/{file}` so the Edit button now points to the correct main-story chapter.